### PR TITLE
Add blame filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.2.0](releases/tag/v0.2.0) - development in progress
+
+### Added
+- `--blame-filter` argument.
+
+### Changed
+- Compatible with Python v3.8.  Previously, Python v3.9 was required.
+
+### Compatibility
+- Python 3.8+
+
+## [0.1.0](releases/tag/v0.1.0) - 2021-11-11
+
+### Added
+- Initial versions of commands `blame`, `csv`, `diff`, `html`, `ls`, `summary`, `trend`, `usage` and `word` created in Microsoft Global Hackathon 2021.
+
+### Compatibility
+- Python 3.9+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,8 @@ Pull requests are welcome.
 
 ## Prerequisites
 
-You need Python 3.9 or later installed.
+- You need Python 3.8 installed.
+  - This is the minimum supported version of the tool.  Developing with a later version risks introducing type hints such as `list[dict]` that are not compatible with Python 3.8.
 
 ## Running without installing
 

--- a/README.md
+++ b/README.md
@@ -9,14 +9,25 @@ Read more about the SARIF format here: https://sarifweb.azurewebsites.net/
 You need Python 3.9 or later installed.  This document assumes that the `python` command runs that version.
 
 ```
-python -m pip install sarif-tools
+pip install sarif-tools
 ```
 
-A script called `sarif` is created in the Python installation's `Scripts` directory.  The `Scripts` directory needs to be in the `PATH`
-environment variable for you to be able to type `sarif` at the command prompt; this is most likely the case if `pip` is run as a
-super-user when installing (e.g. Admin CMD or using `sudo`).
+You should then be able to run:
+```
+sarif --version
+```
 
-If the `Scripts` directory is not in the `PATH`, then you need to run `python -m sarif` instead of `sarif` to run the tool.
+## Troubleshooting installation
+
+This section has suggestions in case the `sarif` command is not available after installation.
+
+A launcher called `sarif` or `sarif.exe` is created in the Python installation's `Scripts` directory.  The `Scripts` directory needs to be in the `PATH`
+environment variable for you to be able to type `sarif` at the command prompt; this is most likely the case if `pip` is run as a
+super-user when installing (e.g. Admin CMD or using `sudo`).  "Admin CMD" here means Command Prompt > Run As Administrator in the Windows Start menu.
+
+If the `Scripts` directory is not in the `PATH`, then you need to type `python -m sarif` instead of `sarif` to run the tool.
+
+Confusion can arise when the `python` and `pip` commands on the `PATH` are from different installations, or the `python` installation on the super-user's `PATH` is different from the `python` command on the normal user's path.  On Windows, you can use `where python` and `where pip` in normal CMD and Admin CMD to see which installations are in use; on Linux, it's `which python` and `which pip` with and without `sudo`.
 
 # Command Line Usage
 

--- a/README.md
+++ b/README.md
@@ -6,13 +6,25 @@ Read more about the SARIF format here: https://sarifweb.azurewebsites.net/
 
 # Installation
 
-You need Python 3.9 or later installed.  This document assumes that the `python` command runs that version.
+## Prerequisites
 
+You need Python 3.9 or later installed.  Get it from [python.org](https://www.python.org/downloads/).  This document assumes that the `python` command runs that version.
+
+## Installing on Windows
+
+Open an Admin Command Prompt (Start > Command Prompt > Run as Administrator) and type:
 ```
 pip install sarif-tools
 ```
 
-You should then be able to run:
+## Installing on Linux or Mac
+```
+sudo pip install sarif-tools
+```
+
+## Testing the installation
+
+After installing using `pip`, you should then be able to run:
 ```
 sarif --version
 ```
@@ -23,7 +35,7 @@ This section has suggestions in case the `sarif` command is not available after 
 
 A launcher called `sarif` or `sarif.exe` is created in the Python installation's `Scripts` directory.  The `Scripts` directory needs to be in the `PATH`
 environment variable for you to be able to type `sarif` at the command prompt; this is most likely the case if `pip` is run as a
-super-user when installing (e.g. Admin CMD or using `sudo`).  "Admin CMD" here means Command Prompt > Run As Administrator in the Windows Start menu.
+super-user when installing (e.g. Administrator Command Prompt on Windows, or using `sudo` on Linux).
 
 If the `Scripts` directory is not in the `PATH`, then you need to type `python -m sarif` instead of `sarif` to run the tool.
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,242 @@ sarif blame -o "C:\temp\sarif_files_with_blame_info" -c "C:\code\my_source_repo"
 
 If the current working directory is the git repository, the `-c` argument can be omitted.
 
+See [Blame filtering](blame-filtering) below for the format of the blame information that gets added to the SARIF files.
+
+### csv
+
+```
+usage: sarif csv [-h] [--output OUTPUT] [--blame-filter FILE] [--autotrim] [--trim PREFIX] [file_or_dir ...]
+
+positional arguments:
+  file_or_dir           A SARIF file or a directory containing SARIF files
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --output OUTPUT, -o OUTPUT
+                        Output file or directory
+  --blame-filter FILE, -b FILE
+                        Specify the blame filter file to apply. See README for format.
+  --autotrim, -a        Strip off the common prefix of paths in the CSV output
+  --trim PREFIX         Prefix to strip from issue paths, e.g. the checkout directory on the build agent
+```
+
+Write out a simple tabular list of issues from [a set of] SARIF files.  This can then be analysed, e.g. via Pivot Tables in Excel.
+
+Use the `--trim` option to strip specific prefixes from the paths, to make the CSV less verbose.  Alternatively, use `--autotrim` to strip off the longest common prefix.
+
+Generate a CSV summary of a single SARIF file with common file path prefix suppressed:
+```shell
+sarif csv "C:\temp\sarif_files\devskim_myapp.sarif"
+```
+
+Generate a CSV summary of a directory of SARIF files with path prefix `C:\code\my_source_repo` suppressed:
+```shell
+sarif csv --trim c:\code\my_source_repo "C:\temp\sarif_files"
+```
+
+See [Blame filtering](blame-filtering) below for how to use the `--blame-filter` option.
+
+### diff
+
+```
+usage: sarif diff [-h] [--output OUTPUT] [--blame-filter FILE] old_file_or_dir new_file_or_dir
+
+positional arguments:
+  old_file_or_dir       An old SARIF file or a directory containing the old SARIF files
+  new_file_or_dir       A new SARIF file or a directory containing the new SARIF files
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --output OUTPUT, -o OUTPUT
+                        Output file
+  --blame-filter FILE, -b FILE
+                        Specify the blame filter file to apply. See README for format.
+```
+
+Print the difference between two [sets of] SARIF files.
+
+Difference between the issues in two SARIF files:
+```shell
+sarif diff "C:\temp\old_sarif_files\devskim_myapp.sarif" "C:\temp\sarif_files\devskim_myapp.sarif"
+```
+
+Difference between the issues in two directories of SARIF files:
+```shell
+sarif diff "C:\temp\old_sarif_files" "C:\temp\sarif_files"
+```
+
+Write output to JSON file instead of printing to stdout:
+
+```shell
+sarif diff -o mydiff.json "C:\temp\old_sarif_files\devskim_myapp.sarif" "C:\temp\sarif_files\devskim_myapp.sarif"
+```
+
+See [Blame filtering](blame-filtering) below for how to use the `--blame-filter` option.
+
+### html
+
+```
+usage: sarif html [-h] [--output OUTPUT] [--blame-filter FILE] [--no-autotrim] [--image IMAGE] [--trim PREFIX] [file_or_dir ...]
+
+positional arguments:
+  file_or_dir           A SARIF file or a directory containing SARIF files
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --output OUTPUT, -o OUTPUT
+                        Output file or directory
+  --blame-filter FILE, -b FILE
+                        Specify the blame filter file to apply. See README for format.
+  --no-autotrim, -n     Do not strip off the common prefix of paths in the output document
+  --image IMAGE         Image to include at top of file - SARIF logo by default
+  --trim PREFIX         Prefix to strip from issue paths, e.g. the checkout directory on the build agent
+```
+
+Create an HTML file summarising SARIF results.
+
+```shell
+sarif html -o summary.html "C:\temp\sarif_files"
+```
+
+Use the `--trim` option to strip specific prefixes from the paths, to make the generated HTML page less verbose.  The longest common prefix of the paths will be trimmed unless `--no-autotrim` is specified.
+
+Use the `--image` option to provide a header image for the top of the HTML page.  The image is embedded into the HTML, so the HTML document remains a portable standalone file.
+
+See [Blame filtering](blame-filtering) below for how to use the `--blame-filter` option.
+
+### ls
+
+```
+usage: sarif ls [-h] [--output OUTPUT] [file_or_dir ...]
+
+positional arguments:
+  file_or_dir           A SARIF file or a directory containing SARIF files
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --output OUTPUT, -o OUTPUT
+                        Output file
+```
+
+List SARIF files in one or more directories.
+
+```shell
+sarif ls "C:\temp\sarif_files" "C:\temp\sarif_with_date"
+```
+
+### summary
+
+```
+usage: sarif summary [-h] [--output OUTPUT] [--blame-filter FILE] [file_or_dir ...]
+
+positional arguments:
+  file_or_dir           A SARIF file or a directory containing SARIF files
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --output OUTPUT, -o OUTPUT
+                        Output file or directory
+  --blame-filter FILE, -b FILE
+                        Specify the blame filter file to apply. See README for format.
+```
+
+Print a summary of the issues in one or more SARIF file(s), grouped by severity and then ordered by number of occurrences.
+
+When directories are provided as input and output, a summary is written for each input file, along with another file containing the totals.
+
+```shell
+sarif summary -o summaries "C:\temp\sarif_files"
+```
+
+When no output directory or file is specified, the overall summary is printed to the standard output.
+
+```shell
+sarif summary "C:\temp\sarif_files\devskim_myapp.sarif"
+```
+
+See [Blame filtering](blame-filtering) below for how to use the `--blame-filter` option.
+
+### trend
+
+```
+usage: sarif trend [-h] [--output OUTPUT] [--blame-filter FILE] [--dateformat {dmy,mdy,ymd}] [file_or_dir ...]
+
+positional arguments:
+  file_or_dir           A SARIF file or a directory containing SARIF files
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --output OUTPUT, -o OUTPUT
+                        Output file
+  --blame-filter FILE, -b FILE
+                        Specify the blame filter file to apply. See README for format.
+  --dateformat {dmy,mdy,ymd}, -f {dmy,mdy,ymd}
+                        Date component order to use in output CSV. Default is `dmy`
+```
+
+Generate a CSV showing a timeline of issues from a set of SARIF files in a directory.  The SARIF file names must contain a
+timestamp in the specific format `yyyymmddThhhmmss` e.g. `20211012T110000Z`.
+
+The CSV can be loaded in Microsoft Excel for graphing and trend analysis.
+
+```shell
+sarif trend -o timeline.csv "C:\temp\sarif_with_date" --dateformat dmy
+```
+
+See [Blame filtering](blame-filtering) below for how to use the `--blame-filter` option.
+
+### usage
+
+Print usage and exit.
+
+```shell
+sarif usage
+```
+
+### word
+
+```
+usage: sarif word [-h] [--output OUTPUT] [--blame-filter FILE] [--no-autotrim] [--image IMAGE] [--trim PREFIX] [file_or_dir ...]
+
+positional arguments:
+  file_or_dir           A SARIF file or a directory containing SARIF files
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --output OUTPUT, -o OUTPUT
+                        Output file or directory
+  --blame-filter FILE, -b FILE
+                        Specify the blame filter file to apply. See README for format.
+  --no-autotrim, -n     Do not strip off the common prefix of paths in the output document
+  --image IMAGE         Image to include at top of file - SARIF logo by default
+  --trim PREFIX         Prefix to strip from issue paths, e.g. the checkout directory on the build agent
+```
+Create Word documents representing a SARIF file or multiple SARIF files.
+
+If directories are provided for the `-o` option and the input, then a Word document is produced for each individual SARIF file
+and for the full set of SARIF files.  Otherwise, a single Word document is created.
+
+Create a Word document for each SARIF file and one for all of them together, in the `reports` directory (created if non-existent):
+```shell
+sarif word -o reports "C:\temp\sarif_files"
+```
+
+Create a Word document for a single SARIF file:
+```shell
+sarif word -o "reports\devskim_myapp.docx" "C:\temp\sarif_files\devskim_myapp.sarif"
+```
+
+Use the `--trim` option to strip specific prefixes from the paths, to make the generated documents less verbose.  The longest common prefix of the paths will be trimmed unless `--no-autotrim` is specified.
+
+Use the `--image` option to provide a header image for the top of the Word document.
+
+See [Blame filtering](blame-filtering) below for how to use the `--blame-filter` option.
+
+# Blame filtering
+
+Use the `sarif blame` command to augment a SARIF file or multiple SARIF files with blame information.
+
 Blame information is added to the property bag of each `result` object for which it was successfully obtained.  The keys and values used are as in the [git blame porcelain format](https://git-scm.com/docs/git-blame#_the_porcelain_format).  E.g.:
 
 ```json
@@ -105,216 +341,48 @@ Blame information is added to the property bag of each `result` object for which
 ```
 Note that the bare `boundary` key is given the automatic value `true`.
 
-This blame data can then be used for filtering and summarising (TODO: future enhancement!).
-
-### csv
+This blame data can then be used for filtering and summarising via the `--blame-filter` option available for various commands.  This option requires a path to a filter-list file, containing a list of patterns and substrings to match against the blame information author email.  The format of a filter-list file is as follows:
 
 ```
-usage: sarif csv [-h] [--output OUTPUT] [--autotrim] [--trim PREFIX] [file_or_dir ...]
-
-positional arguments:
-  file_or_dir           A SARIF file or a directory containing SARIF files
-
-optional arguments:
-  -h, --help            show this help message and exit
-  --output OUTPUT, -o OUTPUT
-                        Output file or directory
-  --autotrim, -a        Strip off the common prefix of paths in the CSV output
-  --trim PREFIX         Prefix to strip from issue paths, e.g. the checkout directory on the build agent
+# Lines beginning with # are interpreted as comments and ignored.
+# A line beginning with "description: " is interpreted as an optional description for the filter.  If no title is specified, the filter file name is used.
+description: Example filter from README.md
+# Lines beginning with "+: " are interpreted as inclusion substrings.  E.g. the following line includes issues whose author-mail field contains "@microsoft.com".
++: @microsoft.com
+# The "+: " can be omitted.
+@microsoft.com
+# Instead of a substring, a regular expression can be used, enclosed in "/" characters.  Issues whose author-mail field includes a string matching the regular expression are included.  Use ^ and $ to match the whole author-mail field.
++: /^<myname.*\.com>$/
+# Again, the "+: " can be omitted for a regular expression include pattern.
+/^<myname.*\.com>$/
+# Lines beginning with "-: " are interpreted as exclusion substrings.  E.g. the following line excludes issues whose author-mail field contains "@microsoft.com".
+-: @bad.microsoft.com
+# Instead of a substring, a regular expression can be used, enclosed in "/" characters.  Issues whose author-mail field includes a string matching the regular expression are excluded.  Use ^ and $ to match the whole author-mail field.  E.g. the following pattern excludes all issues whose author-mail field contains a GUID.
+-: /[0-9A-F]{8}[-][0-9A-F]{4}[-][0-9A-F]{4}[-][0-9A-F]{4}[-][0-9A-F]{12}/
 ```
 
-Write out a simple tabular list of issues from [a set of] SARIF files.  This can then be analysed, e.g. via Pivot Tables in Excel.
-
-Use the `--trim` option to strip specific prefixes from the paths, to make the CSV less verbose.  Alternatively, use `--autotrim` to strip off the longest common prefix.
-
-Generate a CSV summary of a single SARIF file with common file path prefix suppressed:
-```shell
-sarif csv "C:\temp\sarif_files\devskim_myapp.sarif"
-```
-
-Generate a CSV summary of a directory of SARIF files with path prefix `C:\code\my_source_repo` suppressed:
-```shell
-sarif csv --trim c:\code\my_source_repo "C:\temp\sarif_files"
-```
-
-### diff
+Or, without the comments and alternative forms:
 
 ```
-usage: sarif diff [-h] [--output OUTPUT] old_file_or_dir new_file_or_dir
-
-positional arguments:
-  old_file_or_dir       An old SARIF file or a directory containing the old SARIF files
-  new_file_or_dir       A new SARIF file or a directory containing the new SARIF files
-
-optional arguments:
-  -h, --help            show this help message and exit
-  --output OUTPUT, -o OUTPUT
-                        Output file or directory
+description: Example filter from README.md
++: @microsoft.com
++: /^<myname.*\.com>$/
+-: @bad.microsoft.com
+-: /[0-9A-F]{8}[-][0-9A-F]{4}[-][0-9A-F]{4}[-][0-9A-F]{4}[-][0-9A-F]{12}/
 ```
 
-Print the difference between two [sets of] SARIF files.
+All matching is case insensitive, because email addresses are.  Whitespace at the start and end of lines is ignored, which also means that line ending characters don't matter.  The blame filter file must be UTF-8 encoded (including plain ASCII7).  It can have a byte order mark or not.
 
-Difference between the issues in two SARIF files:
-```shell
-sarif diff "C:\temp\old_sarif_files\devskim_myapp.sarif" "C:\temp\sarif_files\devskim_myapp.sarif"
-```
+If there are no inclusion patterns, all issues are included except for those matching the exclusion patterns.  If there are inclusion patterns, only issues matching the inclusion patterns are included.  If an issue matches one or more inclusion patterns and also at least one exclusion pattern, it is excluded.
 
-Difference between the issues in two directories of SARIF files:
-```shell
-sarif diff "C:\temp\old_sarif_files" "C:\temp\sarif_files"
-```
-
-Write output to JSON file instead of printing to stdout:
-
-```shell
-sarif diff -o mydiff.json "C:\temp\old_sarif_files\devskim_myapp.sarif" "C:\temp\sarif_files\devskim_myapp.sarif"
-```
-
-
-### html
+Sometimes, there may be issues in the SARIF file to which the filter cannot be applied, because blame information is not available.  This can be for two reasons: either there is no blame information recorded for the file in which the issue occurred, or the issue location lacks a line number (or specifies line number 1 as a placeholder) so that blame information cannot be correlated to the issue.  These issues are included by default.  To identify which issues these are, create a filter file that excludes everything to which the filter can be applied:
 
 ```
-usage: sarif html [-h] [--output OUTPUT] [--no-autotrim] [--image IMAGE] [--trim PREFIX] [file_or_dir ...]
-
-positional arguments:
-  file_or_dir           A SARIF file or a directory containing SARIF files
-
-optional arguments:
-  -h, --help            show this help message and exit
-  --output OUTPUT, -o OUTPUT
-                        Output file or directory
-  --no-autotrim, -n     Do not strip off the common prefix of paths in the CSV output
-  --image IMAGE, -i IMAGE
-                        Image to include at top of file - SARIF logo by default
-  --trim PREFIX         Prefix to strip from issue paths, e.g. the checkout directory on the build agent
+description: Exclude everything filterable
+-: /.*/
 ```
 
-Create an HTML file summarising SARIF results.
-
-```shell
-sarif html -o summary.html "C:\temp\sarif_files"
-```
-
-Use the `--trim` option to strip specific prefixes from the paths, to make the generated HTML page less verbose.  The longest common prefix of the paths will be trimmed unless `--no-autotrim` is specified.
-
-Use the `--image` option to provide a header image for the top of the HTML page.  The image is embedded into the HTML, so the HTML document remains a portable standalone file.
-
-### ls
-
-```
-usage: sarif ls [-h] [--output OUTPUT] [file_or_dir ...]
-
-positional arguments:
-  file_or_dir           A SARIF file or a directory containing SARIF files
-
-optional arguments:
-  -h, --help            show this help message and exit
-  --output OUTPUT, -o OUTPUT
-                        Output file
-```
-
-List SARIF files in one or more directories.
-
-```shell
-sarif ls "C:\temp\sarif_files" "C:\temp\sarif_with_date"
-```
-
-### summary
-
-```
-usage: sarif summary [-h] [--output OUTPUT] [file_or_dir ...]
-
-positional arguments:
-  file_or_dir           A SARIF file or a directory containing SARIF files
-
-optional arguments:
-  -h, --help            show this help message and exit
-  --output OUTPUT, -o OUTPUT
-                        Output file or directory
-```
-
-Print a summary of the issues in one or more SARIF file(s), grouped by severity and then ordered by number of occurrences.
-
-When directories are provided as input and output, a summary is written for each input file, along with another file containing the totals.
-
-```shell
-sarif summary -o summaries "C:\temp\sarif_files"
-```
-
-When no output directory or file is specified, the overall summary is printed to the standard output.
-
-```shell
-sarif summary "C:\temp\sarif_files\devskim_myapp.sarif"
-```
-
-### trend
-
-```
-usage: sarif trend [-h] [--output OUTPUT] [--dateformat {dmy,mdy,ymd}] [file_or_dir ...]
-
-positional arguments:
-  file_or_dir           A SARIF file or a directory containing SARIF files
-
-optional arguments:
-  -h, --help            show this help message and exit
-  --output OUTPUT, -o OUTPUT
-                        Output file
-  --dateformat {dmy,mdy,ymd}, -f {dmy,mdy,ymd}
-                        Date component order to use in output CSV. Default is `dmy`
-```
-
-Generate a CSV showing a timeline of issues from a set of SARIF files in a directory.  The SARIF file names must contain a
-timestamp in the specific format `yyyymmddThhhmmss` e.g. `20211012T110000Z`.
-
-The CSV can be loaded in Microsoft Excel for graphing and trend analysis.
-
-```shell
-sarif trend -o timeline.csv "C:\temp\sarif_with_date" --dateformat dmy
-```
-
-### usage
-
-Print usage and exit.
-
-```shell
-sarif usage
-```
-
-### word
-
-```
-usage: sarif word [-h] [--output OUTPUT] [--no-autotrim] [--image IMAGE] [--trim PREFIX] [file_or_dir ...]
-
-positional arguments:
-  file_or_dir           A SARIF file or a directory containing SARIF files
-
-optional arguments:
-  -h, --help            show this help message and exit
-  --output OUTPUT, -o OUTPUT
-                        Output file or directory
-  --no-autotrim, -n     Do not strip off the common prefix of paths in the CSV output
-  --image IMAGE, -i IMAGE
-                        Image to include at top of file - SARIF logo by default
-  --trim PREFIX         Prefix to strip from issue paths, e.g. the checkout directory on the build agent
-```
-Create Word documents representing a SARIF file or multiple SARIF files.
-
-If directories are provided for the `-o` option and the input, then a Word document is produced for each individual SARIF file
-and for the full set of SARIF files.  Otherwise, a single Word document is created.
-
-Create a Word document for each SARIF file and one for all of them together, in the `reports` directory (created if non-existent):
-```shell
-sarif word -o reports "C:\temp\sarif_files"
-```
-
-Create a Word document for a single SARIF file:
-```shell
-sarif word -o "reports\devskim_myapp.docx" "C:\temp\sarif_files\devskim_myapp.sarif"
-```
-
-Use the `--trim` option to strip specific prefixes from the paths, to make the generated documents less verbose.  The longest common prefix of the paths will be trimmed unless `--no-autotrim` is specified.
-
-Use the `--image` option to provide a header image for the top of the Word document.
+Then run a `sarif` command using this filter file as the `--blame-filter` to see the default-included issues.
 
 # Usage as a Python library
 
@@ -334,7 +402,7 @@ issue_count_by_severity = sarif_data.get_result_count_by_severity()
 error_histogram = sarif_data.get_issue_code_histogram("error")
 ```
 
-## API
+## Result access API
 
 The three classes defined in the `sarif_files` module, `SarifFileSet`, `SarifFile` and `SarifRun`,
 provide similar APIs, which allows SARIF results to be handled similarly at multiple levels of
@@ -400,6 +468,16 @@ These fields and methods allow access to the underlying information about the SA
 - `SarifFile.runs` - a list of `SarifRun` objects contained in the SARIF file.  Most SARIF files
   only contain a single run, but it is possible to aggregate runs from multiple tools into a
   single SARIF file.
+
+### Path shortening API
+
+Call `init_path_prefix_stripping(autotrim, path_prefixes)` on a `SarifFileSet`, `SarifFile` or `SarifRun` object to set up path filtering, either automatically removing the longest common prefix (`autotrim=True`) or removing specific prefixes (`autotrim=False` and a list of strings in `path_prefixes`).
+
+### Blame filtering API
+
+Call `init_blame_filter(filter_description, include_substrings, include_regexes, exclude_substrings, exclude_regexes)` on a `SarifFileSet`, `SarifFile` or `SarifRun` object to set up blame filtering.  `filter_description` is a string and the other parameters are lists of strings (with no `/` characters around the regular expressions).  They correspond in an obvious way to the filter file contents described in [Blame filtering](blame-filtering) above.
+
+Call `get_filter_stats()` to retrieve the filter stats after reading the results or records from sarif files.  It returns `None` if there is no filter, or otherwise a `sarif_file.FilterStats` object with integer fields `filtered_in_result_count`, `filtered_out_result_count`, `missing_blame_count` and `unconvincing_line_number_count`.  Call `to_string()` on the `FilterStats` object for a readable representation of these statistics, which also includes the filter file name or description (`filter_description` field).
 
 # Suggested usage in CI pipelines
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Read more about the SARIF format here: https://sarifweb.azurewebsites.net/
 
 ## Prerequisites
 
-You need Python 3.9 or later installed.  Get it from [python.org](https://www.python.org/downloads/).  This document assumes that the `python` command runs that version.
+You need Python 3.8 or later installed.  Get it from [python.org](https://www.python.org/downloads/).  This document assumes that the `python` command runs that version.
 
 ## Installing on Windows
 
@@ -84,16 +84,16 @@ The commands are illustrated below assuming input files in the following locatio
 
 ### blame
 ```
-usage: sarif blame [-h] [--output OUTPUT] [--code CODE] [file_or_dir ...]
+usage: sarif blame [-h] [--output PATH] [--code PATH] [file_or_dir [file_or_dir ...]]
 
 positional arguments:
   file_or_dir           A SARIF file or a directory containing SARIF files
 
 optional arguments:
   -h, --help            show this help message and exit
-  --output OUTPUT, -o OUTPUT
+  --output PATH, -o PATH
                         Output file or directory
-  --code CODE, -c CODE  Path to git repository; if not specified, the current working directory is used
+  --code PATH, -c PATH  Path to git repository; if not specified, the current working directory is used
 ```
 
 Augment SARIF files with `git blame` information, and write the augmented files to a specified location.
@@ -108,14 +108,14 @@ See [Blame filtering](blame-filtering) below for the format of the blame informa
 ### csv
 
 ```
-usage: sarif csv [-h] [--output OUTPUT] [--blame-filter FILE] [--autotrim] [--trim PREFIX] [file_or_dir ...]
+usage: sarif csv [-h] [--output PATH] [--blame-filter FILE] [--autotrim] [--trim PREFIX] [file_or_dir [file_or_dir ...]]
 
 positional arguments:
   file_or_dir           A SARIF file or a directory containing SARIF files
 
 optional arguments:
   -h, --help            show this help message and exit
-  --output OUTPUT, -o OUTPUT
+  --output PATH, -o PATH
                         Output file or directory
   --blame-filter FILE, -b FILE
                         Specify the blame filter file to apply. See README for format.
@@ -142,7 +142,7 @@ See [Blame filtering](blame-filtering) below for how to use the `--blame-filter`
 ### diff
 
 ```
-usage: sarif diff [-h] [--output OUTPUT] [--blame-filter FILE] old_file_or_dir new_file_or_dir
+usage: sarif diff [-h] [--output FILE] [--blame-filter FILE] old_file_or_dir new_file_or_dir
 
 positional arguments:
   old_file_or_dir       An old SARIF file or a directory containing the old SARIF files
@@ -150,7 +150,7 @@ positional arguments:
 
 optional arguments:
   -h, --help            show this help message and exit
-  --output OUTPUT, -o OUTPUT
+  --output FILE, -o FILE
                         Output file
   --blame-filter FILE, -b FILE
                         Specify the blame filter file to apply. See README for format.
@@ -179,14 +179,14 @@ See [Blame filtering](blame-filtering) below for how to use the `--blame-filter`
 ### html
 
 ```
-usage: sarif html [-h] [--output OUTPUT] [--blame-filter FILE] [--no-autotrim] [--image IMAGE] [--trim PREFIX] [file_or_dir ...]
+usage: sarif html [-h] [--output PATH] [--blame-filter FILE] [--no-autotrim] [--image IMAGE] [--trim PREFIX] [file_or_dir [file_or_dir ...]]
 
 positional arguments:
   file_or_dir           A SARIF file or a directory containing SARIF files
 
 optional arguments:
   -h, --help            show this help message and exit
-  --output OUTPUT, -o OUTPUT
+  --output PATH, -o PATH
                         Output file or directory
   --blame-filter FILE, -b FILE
                         Specify the blame filter file to apply. See README for format.
@@ -210,14 +210,14 @@ See [Blame filtering](blame-filtering) below for how to use the `--blame-filter`
 ### ls
 
 ```
-usage: sarif ls [-h] [--output OUTPUT] [file_or_dir ...]
+usage: sarif ls [-h] [--output FILE] [file_or_dir [file_or_dir ...]]
 
 positional arguments:
   file_or_dir           A SARIF file or a directory containing SARIF files
 
 optional arguments:
   -h, --help            show this help message and exit
-  --output OUTPUT, -o OUTPUT
+  --output FILE, -o FILE
                         Output file
 ```
 
@@ -230,14 +230,14 @@ sarif ls "C:\temp\sarif_files" "C:\temp\sarif_with_date"
 ### summary
 
 ```
-usage: sarif summary [-h] [--output OUTPUT] [--blame-filter FILE] [file_or_dir ...]
+usage: sarif summary [-h] [--output PATH] [--blame-filter FILE] [file_or_dir [file_or_dir ...]]
 
 positional arguments:
   file_or_dir           A SARIF file or a directory containing SARIF files
 
 optional arguments:
   -h, --help            show this help message and exit
-  --output OUTPUT, -o OUTPUT
+  --output PATH, -o PATH
                         Output file or directory
   --blame-filter FILE, -b FILE
                         Specify the blame filter file to apply. See README for format.
@@ -262,14 +262,14 @@ See [Blame filtering](blame-filtering) below for how to use the `--blame-filter`
 ### trend
 
 ```
-usage: sarif trend [-h] [--output OUTPUT] [--blame-filter FILE] [--dateformat {dmy,mdy,ymd}] [file_or_dir ...]
+usage: sarif trend [-h] [--output FILE] [--blame-filter FILE] [--dateformat {dmy,mdy,ymd}] [file_or_dir [file_or_dir ...]]
 
 positional arguments:
   file_or_dir           A SARIF file or a directory containing SARIF files
 
 optional arguments:
   -h, --help            show this help message and exit
-  --output OUTPUT, -o OUTPUT
+  --output FILE, -o FILE
                         Output file
   --blame-filter FILE, -b FILE
                         Specify the blame filter file to apply. See README for format.
@@ -299,14 +299,14 @@ sarif usage
 ### word
 
 ```
-usage: sarif word [-h] [--output OUTPUT] [--blame-filter FILE] [--no-autotrim] [--image IMAGE] [--trim PREFIX] [file_or_dir ...]
+usage: sarif word [-h] [--output PATH] [--blame-filter FILE] [--no-autotrim] [--image IMAGE] [--trim PREFIX] [file_or_dir [file_or_dir ...]]
 
 positional arguments:
   file_or_dir           A SARIF file or a directory containing SARIF files
 
 optional arguments:
   -h, --help            show this help message and exit
-  --output OUTPUT, -o OUTPUT
+  --output PATH, -o PATH
                         Output file or directory
   --blame-filter FILE, -b FILE
                         Specify the blame filter file to apply. See README for format.
@@ -378,19 +378,19 @@ description: Example filter from README.md
 +: /^<myname.*\.com>$/
 # Again, the "+: " can be omitted for a regular expression include pattern.
 /^<myname.*\.com>$/
-# Lines beginning with "-: " are interpreted as exclusion substrings.  E.g. the following line excludes issues whose author-mail field contains "@microsoft.com".
--: @bad.microsoft.com
+# Lines beginning with "-: " are interpreted as exclusion substrings.  E.g. the following line excludes issues whose author-mail field contains "bot@microsoft.com".
+-: bot@microsoft.com
 # Instead of a substring, a regular expression can be used, enclosed in "/" characters.  Issues whose author-mail field includes a string matching the regular expression are excluded.  Use ^ and $ to match the whole author-mail field.  E.g. the following pattern excludes all issues whose author-mail field contains a GUID.
 -: /[0-9A-F]{8}[-][0-9A-F]{4}[-][0-9A-F]{4}[-][0-9A-F]{4}[-][0-9A-F]{12}/
 ```
 
-Or, without the comments and alternative forms:
+Here's an example of a filter-file that includes issues on lines changed by an `@microsoft.com` email address or a `myname.SOMETHING.com` email address, but not if those email addresses end in `bot@microsoft.com` or contain a GUID.  It's the same as the above example, with comments stripped out.
 
 ```
 description: Example filter from README.md
 +: @microsoft.com
 +: /^<myname.*\.com>$/
--: @bad.microsoft.com
+-: bot@microsoft.com
 -: /[0-9A-F]{8}[-][0-9A-F]{4}[-][0-9A-F]{4}[-][0-9A-F]{4}[-][0-9A-F]{12}/
 ```
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = sarif-tools
-version = 0.1.0
+version = 0.2.0
 author = Microsoft
 description = SARIF tools
 long_description = file: README.md
@@ -21,8 +21,8 @@ packages = find:
 python_requires = >= 3.9
 install_requires =
     python-docx == 0.8.11
-    matplotlib == 3.4.3
-    jinja2 == 3.0.2
+    matplotlib == 3.5.1
+    jinja2 == 3.0.3
 
 [options.entry_points]
 console_scripts =

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@ include_package_data = True
 package_dir =
     = src
 packages = find:
-python_requires = >= 3.9
+python_requires = >= 3.8
 install_requires =
     python-docx == 0.8.11
     matplotlib == 3.5.1

--- a/src/sarif/__main__.py
+++ b/src/sarif/__main__.py
@@ -1,4 +1,6 @@
-# This file supports `python -m sarif` invocation.
+"""
+This file supports `python -m sarif` invocation.
+"""
 
 import sys
 

--- a/src/sarif/cmdline/main.py
+++ b/src/sarif/cmdline/main.py
@@ -88,12 +88,12 @@ Run `sarif <COMMAND> --help` for command-specific help.
 
     for cmd in ["blame", "csv", "html", "summary", "word"]:
         subparser[cmd].add_argument(
-            "--output", "-o", type=str, help="Output file or directory"
+            "--output", "-o", type=str, metavar="PATH", help="Output file or directory"
         )
     for cmd in ["diff", "ls", "trend", "usage"]:
-        subparser[cmd].add_argument("--output", "-o", type=str, help="Output file")
+        subparser[cmd].add_argument("--output", "-o", type=str, metavar="FILE", help="Output file")
 
-    for cmd in ["csv", "diff", "summary", "html", "trend", "word"]:
+    for cmd in ["csv", "diff", "html", "summary", "trend", "word"]:
         subparser[cmd].add_argument(
             "--blame-filter",
             "-b",

--- a/src/sarif/cmdline/main.py
+++ b/src/sarif/cmdline/main.py
@@ -91,7 +91,9 @@ Run `sarif <COMMAND> --help` for command-specific help.
             "--output", "-o", type=str, metavar="PATH", help="Output file or directory"
         )
     for cmd in ["diff", "ls", "trend", "usage"]:
-        subparser[cmd].add_argument("--output", "-o", type=str, metavar="FILE", help="Output file")
+        subparser[cmd].add_argument(
+            "--output", "-o", type=str, metavar="FILE", help="Output file"
+        )
 
     for cmd in ["csv", "diff", "html", "summary", "trend", "word"]:
         subparser[cmd].add_argument(

--- a/src/sarif/operations/blame_op.py
+++ b/src/sarif/operations/blame_op.py
@@ -81,13 +81,16 @@ def _enhance_with_blame(input_files, repo_path):
         file_path = record["Location"]
         if file_path in file_blame_info:
             blame_info = file_blame_info[file_path]
-            line_no = str(record["Line"])
-            if line_no in blame_info["line_to_commit"]:
-                commit_hash = blame_info["line_to_commit"][line_no]
-                commit = blame_info["commits"][commit_hash]
-                # Add blame information to the SARIF Property Bag of the result
-                result.setdefault("properties", {})["blame"] = commit
-                blame_info_count += 1
+            # raw_line can be None if no line number information was included in the SARIF result.
+            raw_line = record["Line"]
+            if raw_line:
+                line_no = str(raw_line)
+                if line_no in blame_info["line_to_commit"]:
+                    commit_hash = blame_info["line_to_commit"][line_no]
+                    commit = blame_info["commits"][commit_hash]
+                    # Add blame information to the SARIF Property Bag of the result
+                    result.setdefault("properties", {})["blame"] = commit
+                    blame_info_count += 1
     print(f"Found blame information for {blame_info_count} of {item_count} results")
 
 

--- a/src/sarif/operations/csv_op.py
+++ b/src/sarif/operations/csv_op.py
@@ -27,6 +27,9 @@ def generate_csv(input_files: SarifFileSet, output: str, output_multiple_files: 
             _write_to_csv(
                 input_file.get_records(), os.path.join(output, output_file_name)
             )
+            filter_stats = input_file.get_filter_stats()
+            if filter_stats:
+                print(f"  Results are filtered by {filter_stats}")
         output_file = os.path.join(output, "static_analysis_output.csv")
     source_description = input_files.get_description()
     print(
@@ -36,6 +39,9 @@ def generate_csv(input_files: SarifFileSet, output: str, output_multiple_files: 
         os.path.basename(output_file),
     )
     _write_to_csv(input_files.get_records(), output_file)
+    filter_stats = input_files.get_filter_stats()
+    if filter_stats:
+        print(f"  Results are filtered by {filter_stats}")
 
 
 def _write_to_csv(list_of_errors, output_file):

--- a/src/sarif/operations/diff_op.py
+++ b/src/sarif/operations/diff_op.py
@@ -4,6 +4,7 @@ Code for `sarif diff` command.
 
 import json
 import sys
+from typing import Dict
 
 from sarif.sarif_file import SarifFileSet, SARIF_SEVERITIES
 
@@ -75,7 +76,7 @@ def print_diff(
     return ret
 
 
-def calc_diff(original_sarif: SarifFileSet, new_sarif: SarifFileSet) -> dict:
+def calc_diff(original_sarif: SarifFileSet, new_sarif: SarifFileSet) -> Dict:
     """
     Generate a diff of the issues from the SARIF files.
     original_sarif corresponds to the old files.

--- a/src/sarif/operations/diff_op.py
+++ b/src/sarif/operations/diff_op.py
@@ -56,6 +56,12 @@ def print_diff(
             _signed_change(diff["all"]["+"]),
             _signed_change(-diff["all"]["-"]),
         )
+    filter_stats = original_sarif.get_filter_stats()
+    if filter_stats:
+        print(f"  'Before' results were filtered by {filter_stats}")
+    filter_stats = new_sarif.get_filter_stats()
+    if filter_stats:
+        print(f"  'After' results were filtered by {filter_stats}")
     ret = 0
     if check_level:
         for severity in SARIF_SEVERITIES:

--- a/src/sarif/operations/html_op.py
+++ b/src/sarif/operations/html_op.py
@@ -27,7 +27,6 @@ def generate_html(
     """
     Generate HTML file from the input files.
     """
-    print(_TEMPLATES_PATH)
     date_val = datetime.now()
 
     if image_file:
@@ -104,6 +103,11 @@ def _generate_single_html(
     else:
         chart_image_data_base64 = None
 
+    filtered = None
+    filter_stats = input_file.get_filter_stats()
+    if filter_stats:
+        filtered = f"Results were filtered by {filter_stats}."
+
     template = _ENV.get_template("sarif_summary.html")
     html_content = template.render(
         report_type=", ".join(all_tools),
@@ -114,6 +118,7 @@ def _generate_single_html(
         image_mime_type=image_mime_type,
         image_data_base64=image_data_base64,
         chart_image_data_base64=chart_image_data_base64,
+        filtered=filtered,
     )
 
     with open(output_file, "wt", encoding="utf-8") as file_out:

--- a/src/sarif/operations/ls_op.py
+++ b/src/sarif/operations/ls_op.py
@@ -2,10 +2,12 @@
 Code for `sarif ls` command.
 """
 
+from typing import List
+
 from sarif import loader
 
 
-def print_ls(files_or_dirs: list[str], output):
+def print_ls(files_or_dirs: List[str], output):
     """
     Print a SARIF file listing for each of the input files or directories.
     """

--- a/src/sarif/operations/summary_op.py
+++ b/src/sarif/operations/summary_op.py
@@ -3,6 +3,7 @@ Code for `sarif summary` command.
 """
 
 import os
+from typing import List
 
 from sarif import sarif_file
 from sarif.sarif_file import SarifFileSet
@@ -51,7 +52,7 @@ def generate_summary(
             print(lstr)
 
 
-def _generate_summary(input_files: SarifFileSet) -> list[str]:
+def _generate_summary(input_files: SarifFileSet) -> List[str]:
     """
     For each severity level (in priority order): create a list of the errors of
     that severity, print out how many there are and then do some further analysis

--- a/src/sarif/operations/summary_op.py
+++ b/src/sarif/operations/summary_op.py
@@ -64,4 +64,7 @@ def _generate_summary(input_files: SarifFileSet) -> list[str]:
         result_count = result_count_by_severity.get(severity, 0)
         ret.append(f"\n{severity}: {result_count}")
         ret += [f" - {code}: {count}" for (code, count) in issue_code_histogram]
+    filter_stats = input_files.get_filter_stats()
+    if filter_stats:
+        ret.append(f"\nResults were filtered by {filter_stats}")
     return ret

--- a/src/sarif/operations/templates/sarif_summary.html
+++ b/src/sarif/operations/templates/sarif_summary.html
@@ -89,7 +89,10 @@
 
 <h3>Sarif Summary: <b>{{ report_type }}</b></h3>
 <h4>Document generated on: <b>{{ report_date }}</b></h4>
-<h4>Total number of various severities ({{ severities }}): <b>{{ total }}</b></h4>
+<h4>Total number of distinct issues of all severities ({{ severities }}): <b>{{ total }}</b></h4>
+{% if filtered -%}
+<p>{{ filtered }}</p>
+{%- endif %}
 
 {% if chart_image_data_base64 -%}
 <img src="data:image/png;base64,{{ chart_image_data_base64 }}" role="img" aria-label="Pie chart" />

--- a/src/sarif/operations/trend_op.py
+++ b/src/sarif/operations/trend_op.py
@@ -3,6 +3,7 @@ Code for `sarif trend` command.
 """
 
 import csv
+from typing import Dict, List
 
 from sarif import sarif_file
 from sarif.sarif_file import SarifFileSet
@@ -63,7 +64,7 @@ def generate_trend_csv(input_files: SarifFileSet, output_file: str, dateformat: 
         print(f"  Results are filtered by {filter_stats}")
 
 
-def _write_csv(output_file: str, error_storage: list[dict]) -> None:
+def _write_csv(output_file: str, error_storage: List[Dict]) -> None:
     # newline="" to avoid \r\r\n - see https://stackoverflow.com/a/3191811/316578
     with open(output_file, "w", newline="", encoding="utf-8") as file_out:
         writer = csv.DictWriter(file_out, TIMESTAMP_COLUMNS, extrasaction="ignore")
@@ -72,7 +73,7 @@ def _write_csv(output_file: str, error_storage: list[dict]) -> None:
             writer.writerow(key)
 
 
-def _store_errors(timestamp, excel_date, tool: str, list_of_errors: list[dict]) -> dict:
+def _store_errors(timestamp, excel_date, tool: str, list_of_errors: List[Dict]) -> Dict:
     results = {
         "_timestamp": timestamp,  # not written to CSV, but used for sorting
         "Date": excel_date,

--- a/src/sarif/operations/trend_op.py
+++ b/src/sarif/operations/trend_op.py
@@ -58,6 +58,9 @@ def generate_trend_csv(input_files: SarifFileSet, output_file: str, dateformat: 
 
     print("Writing trend CSV to", output_file)
     _write_csv(output_file, error_storage)
+    filter_stats = input_files.get_filter_stats()
+    if filter_stats:
+        print(f"  Results are filtered by {filter_stats}")
 
 
 def _write_csv(output_file: str, error_storage: list[dict]) -> None:

--- a/src/sarif/sarif_file.py
+++ b/src/sarif/sarif_file.py
@@ -6,7 +6,7 @@ files, along with associated functions and constants.
 import copy
 import os
 import re
-from typing import Iterator, Optional, Tuple
+from typing import Dict, Iterator, List, Optional, Tuple
 
 SARIF_SEVERITIES = ["error", "warning", "note"]
 
@@ -31,7 +31,7 @@ def has_sarif_file_extension(filename):
 
 def _read_result_location(result) -> Tuple[str, str]:
     """
-    Extract the file path and line number (latter as a string) from the Result.
+    Extract the file path and line number strings from the Result.
     Tools store this in different ways, so this function tries a few different JSON locations.
     """
     file_path = None
@@ -63,7 +63,7 @@ def _read_result_location(result) -> Tuple[str, str]:
     return (file_path, line_number)
 
 
-def _group_records_by_severity(records) -> dict[str, list[dict]]:
+def _group_records_by_severity(records) -> Dict[str, List[Dict]]:
     """
     Get the records, grouped by severity.
     """
@@ -73,7 +73,7 @@ def _group_records_by_severity(records) -> dict[str, list[dict]]:
     }
 
 
-def _count_records_by_issue_code(records, severity) -> list[tuple]:
+def _count_records_by_issue_code(records, severity) -> List[Tuple]:
     """
     Return a list of pairs (code, count) of the records with the specified
     severities.
@@ -381,7 +381,7 @@ class SarifRun:
         """
         return self.run_data["tool"]["driver"]["name"]
 
-    def get_results(self) -> list[dict]:
+    def get_results(self) -> List[Dict]:
         """
         Get the results from this run.  These are the Result objects as defined in the SARIF
         standard section 3.27.  The results are filtered if a filter has ben configured.
@@ -389,7 +389,7 @@ class SarifRun:
         """
         return self._filter.filter_results(self.run_data["results"])
 
-    def get_records(self) -> list[dict]:
+    def get_records(self) -> List[Dict]:
         """
         Get simplified records derived from the results of this run.  The records have the
         keys defined in `RECORD_ATTRIBUTES`.
@@ -399,7 +399,7 @@ class SarifRun:
             self._cached_records = [self.result_to_record(result) for result in results]
         return self._cached_records
 
-    def get_records_grouped_by_severity(self) -> dict[str, list[dict]]:
+    def get_records_grouped_by_severity(self) -> Dict[str, List[Dict]]:
         """
         Get the records, grouped by severity.
         """
@@ -454,7 +454,7 @@ class SarifRun:
         """
         return len(self.get_results())
 
-    def get_result_count_by_severity(self) -> dict[str, int]:
+    def get_result_count_by_severity(self) -> Dict[str, int]:
         """
         Return a dict from SARIF severity to number of records.
         """
@@ -464,7 +464,7 @@ class SarifRun:
             for severity in SARIF_SEVERITIES
         }
 
-    def get_issue_code_histogram(self, severity) -> list[tuple]:
+    def get_issue_code_histogram(self, severity) -> List[Tuple]:
         """
         Return a list of pairs (code, count) of the records with the specified
         severities.
@@ -590,7 +590,7 @@ class SarifFile:
         """
         return sorted(list(set(run.get_tool_name() for run in self.runs)))
 
-    def get_results(self) -> list[dict]:
+    def get_results(self) -> List[Dict]:
         """
         Get the results from all runs in this file.  These are the Result objects as defined in the
         SARIF standard section 3.27.
@@ -601,7 +601,7 @@ class SarifFile:
             ret += run.get_results()
         return ret
 
-    def get_records(self) -> list[dict]:
+    def get_records(self) -> List[Dict]:
         """
         Get simplified records derived from the results of all runs.  The records have the
         keys defined in `RECORD_ATTRIBUTES`.
@@ -611,7 +611,7 @@ class SarifFile:
             ret += run.get_records()
         return ret
 
-    def get_records_grouped_by_severity(self) -> dict[str, list[dict]]:
+    def get_records_grouped_by_severity(self) -> Dict[str, List[Dict]]:
         """
         Get the records, grouped by severity.
         """
@@ -623,7 +623,7 @@ class SarifFile:
         """
         return sum(run.get_result_count() for run in self.runs)
 
-    def get_result_count_by_severity(self) -> dict[str, int]:
+    def get_result_count_by_severity(self) -> Dict[str, int]:
         """
         Return a dict from SARIF severity to number of records.
         """
@@ -637,7 +637,7 @@ class SarifFile:
             for severity in SARIF_SEVERITIES
         }
 
-    def get_issue_code_histogram(self, severity) -> list[tuple]:
+    def get_issue_code_histogram(self, severity) -> List[Tuple]:
         """
         Return a list of pairs (code, count) of the records with the specified
         severities.
@@ -783,7 +783,7 @@ class SarifFileSet:
         """
         self.files.append(sarif_file_object)
 
-    def get_distinct_tool_names(self) -> list[str]:
+    def get_distinct_tool_names(self) -> List[str]:
         """
         Return a list of tool names that feature in the runs in these files.
         The list is deduplicated and sorted into alphabetical order.
@@ -796,7 +796,7 @@ class SarifFileSet:
 
         return sorted(list(all_tool_names))
 
-    def get_results(self) -> list[dict]:
+    def get_results(self) -> List[Dict]:
         """
         Get the results from all runs in all files.  These are the Result objects as defined in the
         SARIF standard section 3.27.
@@ -809,7 +809,7 @@ class SarifFileSet:
             ret += input_file.get_results()
         return ret
 
-    def get_records(self) -> list[dict]:
+    def get_records(self) -> List[Dict]:
         """
         Get simplified records derived from the results of all runs.  The records have the
         keys defined in `RECORD_ATTRIBUTES`.
@@ -821,7 +821,7 @@ class SarifFileSet:
             ret += input_file.get_records()
         return ret
 
-    def get_records_grouped_by_severity(self) -> dict[str, list[dict]]:
+    def get_records_grouped_by_severity(self) -> Dict[str, List[Dict]]:
         """
         Get the records, grouped by severity.
         """
@@ -835,7 +835,7 @@ class SarifFileSet:
             input_file.get_result_count() for input_file in self.files
         )
 
-    def get_result_count_by_severity(self) -> dict[str, int]:
+    def get_result_count_by_severity(self) -> Dict[str, int]:
         """
         Return a dict from SARIF severity to number of records.
         """
@@ -849,7 +849,7 @@ class SarifFileSet:
             for severity in SARIF_SEVERITIES
         }
 
-    def get_issue_code_histogram(self, severity) -> list[tuple]:
+    def get_issue_code_histogram(self, severity) -> List[Tuple]:
         """
         Return a list of pairs (code, count) of the records with the specified
         severities.


### PR DESCRIPTION
Add the `--blame-filter` option to all the commands for which it makes sense.  It takes a path to a filter-file and filters the results according the the author_mail from the git blame information.