### PR TITLE
Add recursive = True to glob

### DIFF
--- a/sarif/loader.py
+++ b/sarif/loader.py
@@ -29,7 +29,7 @@ def load_sarif_files(*args) -> SarifFileSet:
         for path in args:
             path_exists = _add_path_to_sarif_file_set(path, ret)
             if not path_exists:
-                for resolved_path in glob.glob(path):
+                for resolved_path in glob.glob(path, recursive = True):
                     if _add_path_to_sarif_file_set(resolved_path, ret):
                         path_exists = True
             if not path_exists:


### PR DESCRIPTION
The documentation states:
> The file_or_dir specifier can include wildcards e.g. c:\temp\**\devskim*.sarif (i.e. a "glob").

However it does not currently enable the use of ** when using glob. This PR adds recursive = True to enable it.