### PR TITLE
Add getting message in cases where "text" property is not presented in sarif file per RFC3629

### DIFF
--- a/sarif/sarif_file.py
+++ b/sarif/sarif_file.py
@@ -547,7 +547,14 @@ class SarifRun:
         severity = result.get(
             "level", "warning"
         )  # If an error has no specified level then by default it is a warning
-        message = result["message"]["text"]
+        
+        #per RFC3629 At least one of the text (§3.11.8) or id (§3.11.10) properties SHALL be present https://docs.oasis-open.org/sarif/sarif/v2.1.0/os/sarif-v2.1.0-os.html#RFC3629
+        if "text" in result["message"]:
+            message = result["message"]["text"]
+        elif "id" in result["message"]:
+            message = result["message"]["id"]
+        else:
+            raise Exception("Message for result " + error_id + " from tool " + tool_name + " do not comply with RFC3629. At least one of the text (§3.11.8) or id (§3.11.10) properties SHALL be present https://docs.oasis-open.org/sarif/sarif/v2.1.0/os/sarif-v2.1.0-os.html#RFC3629")
 
         # Create a dict representing this result
         record = {


### PR DESCRIPTION
In some cases message doesn't have "text" attribute and result_to_record call fails with exception:
  File "C:\Python\lib\site-packages\sarif\sarif_file.py", line 550, in result_to_record
    message = result["message"]["text"]
KeyError: 'text'

Example - binskim scan results from Defender for DevOps

Per RFC3629 At least one of the text (§3.11.8) or id (§3.11.10) properties SHALL be present https://docs.oasis-open.org/sarif/sarif/v2.1.0/os/sarif-v2.1.0-os.html#RFC3629 Proposed change checks if message have text or id attribute and use corresponding key to get message.

Sample sarif data:
        {
          "ruleId": "BA2015",
          "ruleIndex": 2,
          "level": "error",
          "message": {
            "id": "Error_NoHighEntropyVA",
            "arguments": [
              "clipboard_x86_64.exe"
            ]
          },