### PR TITLE
Fix #18 - show locations of new issue occurrences

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,69 @@ Write output to JSON file instead of printing to stdout:
 sarif diff -o mydiff.json "C:\temp\old_sarif_files\devskim_myapp.sarif" "C:\temp\sarif_files\devskim_myapp.sarif"
 ```
 
+The JSON format is like this:
+
+```json
+
+{
+    "all": {
+        "+": 5,
+        "-": 11
+    },
+    "error": {
+        "+": 2,
+        "-": 0,
+        "codes": {
+            "XYZ1234 Some Issue": {
+                "<": 0,
+                ">": 2,
+                "+@": [
+                    {
+                        "Location": "C:\\code\\file1.py",
+                        "Line": 119
+                    },
+                    {
+                        "Location": "C:\\code\\file2.py",
+                        "Line": 61
+                    }
+                ]
+            },
+        }
+    },
+    "warning": {
+        "+": 3,
+        "-": 11,
+        "codes": {...}
+    },
+    "note": {
+        "+": 3,
+        "-": 11,
+        "codes": {...}
+    }
+}
+```
+
+Where:
+
+- "+" indicates new issue types at this severity, "error", "warning" or "note"
+- "-" indicates resolved issue types at this severity (no occurrences remaining)
+- "codes" lists each issue code where the number of occurrences has changed:
+  - occurrences before indicated by "<"
+  - occurrences after indicated by ">"
+  - new locations indicated by "+@"
+
+If the set of issue codes at a given severity has changed, diff will report this even if the total
+number of issue types at that severity is unchanged.
+
+When the number of occurrences of an issue code is unchanged, diff will not report this issue code,
+although it is possible that an equal number of new occurrences of the specific issue have arisen as
+have been resolved.  This is to avoid reporting line number changes.
+
+The `diff` operation shows the location of new occurrences of each issue.  When writing to an
+output JSON file, all new locations are written, but when writing output to the console, a maximum
+of three locations are shown.  Note that there can be some false positives here, if line numbers
+have changed.
+
 See [Blame filtering](blame-filtering) below for how to use the `--blame-filter` option.
 
 #### emacs

--- a/sarif/loader.py
+++ b/sarif/loader.py
@@ -42,8 +42,7 @@ def _load_dir(path):
     for dirpath, _dirnames, filenames in os.walk(path):
         for filename in filenames:
             if has_sarif_file_extension(filename):
-                subdir.add_file(load_sarif_file(
-                    os.path.join(dirpath, filename)))
+                subdir.add_file(load_sarif_file(os.path.join(dirpath, filename)))
     return subdir
 
 

--- a/sarif/operations/diff_op.py
+++ b/sarif/operations/diff_op.py
@@ -10,11 +10,15 @@ from sarif.sarif_file import SarifFileSet, SARIF_SEVERITIES
 
 
 def _occurrences(occurrence_count):
-    return "1 occurence" if occurrence_count == 1 else f"{occurrence_count} occurrences"
+    return "1 occurrence" if occurrence_count == 1 else f"{occurrence_count} occurrences"
 
 
 def _signed_change(difference):
     return str(difference) if difference < 0 else f"+{difference}"
+
+
+def _record_to_location_tuple(record) -> str:
+    return (record["Location"], record["Line"])
 
 
 def print_diff(
@@ -40,7 +44,12 @@ def print_diff(
                     _signed_change(diff[severity]["+"]),
                     _signed_change(-diff[severity]["-"]),
                 )
-                for issue_code, old_count, new_count in diff[severity]["codes"]:
+                for issue_code, code_info in diff[severity]["codes"].items():
+                    (old_count, new_count, new_locations) = (
+                        code_info["<"],
+                        code_info[">"],
+                        code_info.get("+@", []),
+                    )
                     if old_count == 0:
                         print(f'  New issue "{issue_code}" ({_occurrences(new_count)})')
                     elif new_count == 0:
@@ -50,6 +59,13 @@ def print_diff(
                             f"  Number of occurrences {old_count} -> {new_count}",
                             f'({_signed_change(new_count - old_count)}) for issue "{issue_code}"',
                         )
+                    if new_locations:
+                        # Print the top 3 new locations
+                        for record in new_locations[0:3]:
+                            (location, line) = _record_to_location_tuple(record)
+                            print(f"    {location}:{line}")
+                        if len(new_locations) > 3:
+                            print("    ...")
             else:
                 print(severity, "level: +0 -0 no changes")
         print(
@@ -76,6 +92,31 @@ def print_diff(
     return ret
 
 
+def _find_new_occurrences(new_records, old_records, issue_code):
+    old_occurrences = [r for r in old_records if r["Code"] == issue_code]
+    new_occurrences_new_locations = []
+    new_occurrences_new_lines = []
+    for r in new_records:
+        if r["Code"] == issue_code:
+            (new_location, new_line) = (True, True)
+            for old_r in old_occurrences:
+                if old_r["Location"] == r["Location"]:
+                    new_location = False
+                    if old_r["Line"] == r["Line"]:
+                        new_line = False
+                        break
+            if new_location:
+                if r not in new_occurrences_new_locations:
+                    new_occurrences_new_locations.append(r)
+            elif new_line:
+                if r not in new_occurrences_new_lines:
+                    new_occurrences_new_lines.append(r)
+
+    return sorted(
+        new_occurrences_new_locations, key=_record_to_location_tuple
+    ) + sorted(new_occurrences_new_lines, key=_record_to_location_tuple)
+
+
 def calc_diff(original_sarif: SarifFileSet, new_sarif: SarifFileSet) -> Dict:
     """
     Generate a diff of the issues from the SARIF files.
@@ -88,16 +129,26 @@ def calc_diff(original_sarif: SarifFileSet, new_sarif: SarifFileSet) -> Dict:
         original_histogram = dict(original_sarif.get_issue_code_histogram(severity))
         new_histogram = new_sarif.get_issue_code_histogram(severity)
         new_histogram_dict = dict(new_histogram)
-        ret[severity] = {"+": 0, "-": 0, "codes": []}
+        ret[severity] = {"+": 0, "-": 0, "codes": {}}
         if original_histogram != new_histogram_dict:
             for issue_code, count in new_histogram:
                 old_count = original_histogram.pop(issue_code, 0)
                 if old_count != count:
-                    ret[severity]["codes"].append((issue_code, old_count, count))
+                    ret[severity]["codes"][issue_code] = {"<": old_count, ">": count}
                     if old_count == 0:
                         ret[severity]["+"] += 1
+                    new_occurrences = _find_new_occurrences(
+                        new_sarif.get_records(),
+                        original_sarif.get_records(),
+                        issue_code,
+                    )
+                    if new_occurrences:
+                        ret[severity]["codes"][issue_code]["+@"] = [
+                            {"Location": r["Location"], "Line": r["Line"]}
+                            for r in new_occurrences
+                        ]
             for issue_code, old_count in original_histogram.items():
-                ret[severity]["codes"].append((issue_code, old_count, 0))
+                ret[severity]["codes"][issue_code] = {"<": old_count, ">": 0}
                 ret[severity]["-"] += 1
         ret["all"]["+"] += ret[severity]["+"]
         ret["all"]["-"] += ret[severity]["-"]

--- a/sarif/operations/html_op.py
+++ b/sarif/operations/html_op.py
@@ -128,7 +128,7 @@ def _enrich_details(histogram, records_of_severity):
     enriched_details = []
 
     for error_code, count in histogram:
-        error_lines = [e for e in records_of_severity if e["Code"] == error_code]
+        error_lines = (e for e in records_of_severity if e["Code"] == error_code)
         lines = sorted(
             error_lines, key=lambda x: x["Location"] + str(x["Line"]).zfill(6)
         )

--- a/sarif/sarif_file.py
+++ b/sarif/sarif_file.py
@@ -751,12 +751,12 @@ class SarifFile:
         """
         Return a dict from SARIF severity to number of records.
         """
-        get_result_count_by_severity_per_run = [
+        result_count_by_severity_per_run = (
             run.get_result_count_by_severity() for run in self.runs
-        ]
+        )
         return {
             severity: sum(
-                rc.get(severity, 0) for rc in get_result_count_by_severity_per_run
+                rc.get(severity, 0) for rc in result_count_by_severity_per_run
             )
             for severity in SARIF_SEVERITIES
         }


### PR DESCRIPTION
Closes https://github.com/microsoft/sarif-tools/issues/18

Diff output now includes locations for (possibly new) occurrences of issues.

Note that this is a breaking change to the diff json output, but hopefully a good one.  We'll call the next version 2.0 as a result.