### PR TITLE
Convert SARIF files to GitLab (Code Climate) format

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ optional arguments:
 Write out a JSON file of Code Climate tool format from [a set of] SARIF files.  
 This can then be published as a Code Quality report artefact in a GitLab pipeline and shown in GitLab UI for merge requests.
 
-The JSON output can also be filtered using the same blame information; see
+The JSON output can also be filtered using the blame information; see
 [Blame filtering](#blame-filtering) below for how to use the `--blame-filter` option.
 
 #### copy

--- a/README.md
+++ b/README.md
@@ -84,12 +84,12 @@ in normal CMD and Admin CMD to see which installations are in use; on Linux, it'
 ## Command Line Usage
 
 ```plain
-usage: sarif [-h] [--version] [--debug] [--check {error,warning,note}] {blame,copy,csv,diff,emacs,html,info,ls,summary,trend,usage,word} ...
+usage: sarif [-h] [--version] [--debug] [--check {error,warning,note}] {blame,codeclimate,copy,csv,diff,emacs,html,info,ls,summary,trend,usage,word} ...
 
 Process sets of SARIF files
 
 positional arguments:
-  {blame,copy,csv,diff,emacs,html,info,ls,summary,trend,usage,word}
+  {blame,codeclimate,copy,csv,diff,emacs,html,info,ls,summary,trend,usage,word}
                         command
 
 optional arguments:
@@ -100,18 +100,19 @@ optional arguments:
                         Exit with error code if there are any issues of the specified level (or for diff, an increase in issues at that level).
 
 commands:
-blame    Enhance SARIF file with information from `git blame`
-copy     Write a new SARIF file containing optionally-filtered data from other SARIF file(s)
-csv      Write a CSV file listing the issues from the SARIF files(s) specified
-diff     Find the difference between two [sets of] SARIF files
-emacs    Write a representation of SARIF file(s) for viewing in emacs
-html     Write an HTML representation of SARIF file(s) for viewing in a web browser
-info     Print information about SARIF file(s) structure
-ls       List all SARIF files in the directories specified
-summary  Write a text summary with the counts of issues from the SARIF files(s) specified
-trend    Write a CSV file with time series data from SARIF files with "yyyymmddThhmmssZ" timestamps in their filenames
-usage    (Command optional) - print usage and exit
-word     Produce MS Word .docx summaries of the SARIF files specified
+blame        Enhance SARIF file with information from `git blame`
+codeclimate  Write a JSON representation in Code Climate format of SARIF file(s) for viewing as a Code Quality report in GitLab UI
+copy         Write a new SARIF file containing optionally-filtered data from other SARIF file(s)
+csv          Write a CSV file listing the issues from the SARIF files(s) specified
+diff         Find the difference between two [sets of] SARIF files
+emacs        Write a representation of SARIF file(s) for viewing in emacs
+html         Write an HTML representation of SARIF file(s) for viewing in a web browser
+info         Print information about SARIF file(s) structure
+ls           List all SARIF files in the directories specified
+summary      Write a text summary with the counts of issues from the SARIF files(s) specified
+trend        Write a CSV file with time series data from SARIF files with "yyyymmddThhmmssZ" timestamps in their filenames
+usage        (Command optional) - print usage and exit
+word         Produce MS Word .docx summaries of the SARIF files specified
 Run `sarif <COMMAND> --help` for command-specific help.
 ```
 
@@ -150,6 +151,32 @@ sarif blame -o "C:\temp\sarif_files_with_blame_info" -c "C:\code\my_source_repo"
 If the current working directory is the git repository, the `-c` argument can be omitted.
 
 See [Blame filtering](#blame-filtering) below for the format of the blame information that gets added to the SARIF files.
+
+#### codeclimate
+
+```plain
+usage: sarif codeclimate [-h] [--output PATH] [--blame-filter FILE] [--autotrim] [--trim PREFIX] [file_or_dir ...]
+
+Write a JSON representation in Code Climate format of SARIF file(s) for viewing as a Code Quality report in GitLab UI
+
+positional arguments:
+  file_or_dir           A SARIF file or a directory containing SARIF files
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --output PATH, -o PATH
+                        Output file or directory
+  --blame-filter FILE, -b FILE
+                        Specify the blame filter file to apply. See README for format.
+  --autotrim, -a        Strip off the common prefix of paths in the CSV output
+  --trim PREFIX         Prefix to strip from issue paths, e.g. the checkout directory on the build agent
+```
+
+Write out a JSON file of Code Climate tool format from [a set of] SARIF files.  
+This can then be published as a Code Quality report artefact in a GitLab pipeline and shown in GitLab UI for merge requests.
+
+The JSON output can also be filtered using the same blame information; see
+[Blame filtering](#blame-filtering) below for how to use the `--blame-filter` option.
 
 #### copy
 

--- a/sarif/cmdline/main.py
+++ b/sarif/cmdline/main.py
@@ -116,7 +116,7 @@ def _create_arg_parser():
         help='Append current timestamp to output filename in the "yyyymmddThhmmssZ" format used by '
         "the `sarif trend` command",
     )
-    # codeclimate and csv defaults to no trimming
+    # codeclimate and csv default to no trimming
     for cmd in ["codeclimate", "csv"]:
         subparser[cmd].add_argument(
             "--autotrim",

--- a/sarif/operations/codeclimate_op.py
+++ b/sarif/operations/codeclimate_op.py
@@ -1,0 +1,90 @@
+"""
+Code for `sarif codeclimate` command.
+"""
+
+import os
+import json
+import hashlib
+
+from sarif.sarif_file import SarifFileSet
+
+_SEVERITIES = {
+    "none": "info",
+    "note": "info",
+    "warning": "minor",
+    "error": "major"
+}
+
+
+def generate(input_files: SarifFileSet, output: str, output_multiple_files: bool):
+    """
+    Generate a JSON file in Code Climate schema containing the list of issues from the SARIF files.
+    See https://github.com/codeclimate/platform/blob/master/spec/analyzers/SPEC.md
+    Gitlab usage guide - https://docs.gitlab.com/ee/ci/testing/code_quality.html#implement-a-custom-tool
+    """
+    output_file = output
+    if output_multiple_files:
+        for input_file in input_files:
+            output_file_name = input_file.get_file_name_without_extension() + ".json"
+            print(
+                "Writing Code Climate JSON summary of",
+                input_file.get_file_name(),
+                "to",
+                output_file_name,
+            )
+            _write_to_json(
+                input_file.get_records(), os.path.join(output, output_file_name)
+            )
+            filter_stats = input_file.get_filter_stats()
+            if filter_stats:
+                print(f"  Results are filtered by {filter_stats}")
+        output_file = os.path.join(output, "static_analysis_output.json")
+    source_description = input_files.get_description()
+    print(
+        "Writing Code Climate JSON summary for",
+        source_description,
+        "to",
+        os.path.basename(output_file),
+    )
+    _write_to_json(input_files.get_records(), output_file)
+    filter_stats = input_files.get_filter_stats()
+    if filter_stats:
+        print(f"  Results are filtered by {filter_stats}")
+
+
+def _write_to_json(list_of_errors, output_file):
+    """
+    Write out the errors to a JSON file according to Code Climate specification.
+    """
+    content = []
+    for record in list_of_errors:
+        severity = _SEVERITIES.get(record.get("Severity", "warning"), "minor")
+
+        # split Code value to extract error ID and description
+        rule = record["Code"].split(' ', 1)[0]
+        description = record["Code"][len(rule)+1:]
+
+        path = record["Location"]
+        line = record["Line"]
+
+        fingerprint = hashlib.md5(f"{description} {path} ${line}`]".encode()).hexdigest()
+
+        # "categories" property is not used in GitLab by marked as "required" in Code Climate spec.
+        # There is no easy way to determine a category so the fixed value is set.
+        content.append({
+            "type": "issue",
+            "check_name": rule,
+            "description": description,
+            "categories": ["Bug Risk"],
+            "location": {
+                "path": path,
+                "lines": {
+                    "begin": line
+                }
+            },
+            "severity": severity,
+            "fingerprint": fingerprint
+        })
+
+    with open(output_file, "w", encoding="utf-8") as file_out:
+        json.dump(content, file_out, indent=4)

--- a/sarif/operations/codeclimate_op.py
+++ b/sarif/operations/codeclimate_op.py
@@ -69,7 +69,7 @@ def _write_to_json(list_of_errors, output_file):
 
         fingerprint = hashlib.md5(f"{description} {path} ${line}`]".encode()).hexdigest()
 
-        # "categories" property is not used in GitLab by marked as "required" in Code Climate spec.
+        # "categories" property is not used in GitLab but marked as "required" in Code Climate spec.
         # There is no easy way to determine a category so the fixed value is set.
         content.append({
             "type": "issue",


### PR DESCRIPTION
Implemented a new command `sarif codeclimate` to generate output for GitLab Code Quality report.

GitLab uses Code Climate tool for static analysis and a published report is shown in Merge Request UI as a Code Quality report. 

GitLab also provides a way to upload a report generated by custom tool - see https://docs.gitlab.com/ee/ci/testing/code_quality.html#implement-a-custom-tool

Many SAST tools generates SARIF files, so to use them in GitLab they must be converted to Code Climate format which is pretty simple:
```json
[
  {
    "description": "'unused' is assigned a value but never used.",
    "check_name": "no-unused-vars",
    "fingerprint": "7815696ecbf1c96e6894b779456d330e",
    "severity": "minor",
    "location": {
      "path": "lib/index.js",
      "lines": {
        "begin": 42
      }
    }
  }
]
```