### PR TITLE
Fixed error when there are no inclusion filters.

### DIFF
--- a/sarif/filter/general_filter.py
+++ b/sarif/filter/general_filter.py
@@ -107,11 +107,13 @@ class GeneralFilter:
         # Remove any existing filter log on the result
         result.setdefault("properties", {}).pop("filtered", None)
 
-        included_stats = None
         if self.apply_inclusion_filter:
             included_stats = self._filter_result(result, self.include_filters)
             if not included_stats["matchedFilter"]:
                 return
+        else:
+            # no inclusion filters, mark the result as included so far
+            included_stats = {"state": "included", "matchedFilter": []}
 
         if self.apply_exclusion_filter:
             excluded_stats = self._filter_result(result, self.exclude_filters)

--- a/tests/test_general_filter.py
+++ b/tests/test_general_filter.py
@@ -251,6 +251,19 @@ class TestGeneralFilter:
         assert general_filter.filter_stats.filtered_out_result_count == 10
         assert general_filter.filter_stats.missing_property_count == 0
 
+    def test_filter_results_exclude_not_all(self):
+        general_filter = GeneralFilter()
+        general_filter.init_filter("test filter", {}, [], [{"level": "error"}])
+        results = [{"level": "error"}, {"level": "warning"}, {"level": "error"}]
+
+        filtered_results = general_filter.filter_results(results)
+        assert len(filtered_results) == 1
+        assert general_filter.filter_stats.filtered_in_result_count == 1
+        assert general_filter.filter_stats.filtered_out_result_count == 2
+        assert general_filter.filter_stats.missing_property_count == 0
+        assert filtered_results[0]["properties"]["filtered"]["state"] == "included"
+        assert len(filtered_results[0]["properties"]["filtered"]["matchedFilter"]) == 0
+
     def test_filter_results_no_filters(self):
         general_filter = GeneralFilter()
         general_filter.init_filter("test filter", {}, [], [])


### PR DESCRIPTION
Fixes #33.
When there are no inclusion filter `included_stats` is not initialised to a proper value. Set the default value as `included`.
Added a test case to cover