### PR TITLE
Add blame filter upgrade operation

### DIFF
--- a/README.md
+++ b/README.md
@@ -642,14 +642,22 @@ description: Example filter from README.md
 
 # Optional configuration section to override default values.
 configuration:
-  # This option controls whether to include results where a property to check is missing, default value is true.
+  # This option controls whether to include results where a property to check is missing, default
+  # value is true.
   default-include: false
+  # This option only applies filter criteria if the line number is present and not equal to 1.
+  # Some static analysis tools set the line number to 1 for whole file issues, but this does not
+  # work with blame filtering, because who last changed line 1 is irrelevant.  Default value is
+  # true
+  check-line-number: true
 
 # Items in `include` list are interpreted as inclusion filtering rules.
 # Items are treated with OR operator, the filtered results includes objects matching any rule.
-# Each item can be one rule or a list of rules, in the latter case rules in the list are treated with AND operator - all rules must match.
+# Each item can be one rule or a list of rules, in the latter case rules in the list are treated
+# with AND operator - all rules must match.
 include:
-  # The following line includes issues whose author-mail property contains "@microsoft.com" AND found in Java files.
+  # The following line includes issues whose author-mail property contains "@microsoft.com" AND
+  # found in Java files.
   # Values with special characters `\:;_()$%^@,` must be enclosed in quotes (single or double):
   - author-mail: "@microsoft.com"
     locations[*].physicalLocation.artifactLocation.uri: "*.java"
@@ -658,12 +666,13 @@ include:
   # Use ^ and $ to match the whole committer-mail property.
   - committer-mail:
       value: "/^<myname.*\\.com>$/"
-      # Configuration options can be overriden for any rule.
+      # Configuration options can be overridden for any rule.
       default-include: true
-
+      check-line-number: true
 # Lines under `exclude` are interpreted as exclusion filtering rules.
 exclude:
-  # The following line excludes issues whose location is in test Java files with names starting with the "Test" prefix.
+  # The following line excludes issues whose location is in test Java files with names starting with
+  #  the "Test" prefix.
   - location: "Test*.java"
   # The value for the property can be empty, in this case only existence of the property is checked.
   - suppression:

--- a/README.md
+++ b/README.md
@@ -556,6 +556,22 @@ sarif trend -o timeline.csv "C:\temp\sarif_with_date" --dateformat dmy
 
 See [Filtering](#filtering) below for how to use the `--filter` option.
 
+#### upgrade-filter
+
+```plain
+usage: sarif upgrade-filter [-h] [--output PATH] [file [file ...]]
+
+Upgrade a v1-style blame filter file to a v2-style filter YAML file
+
+positional arguments:
+  file                  A v1-style blame-filter file
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --output PATH, -o PATH
+                        Output file or directory
+```
+
 #### usage
 
 ```plain

--- a/sarif/cmdline/main.py
+++ b/sarif/cmdline/main.py
@@ -182,7 +182,7 @@ def _create_arg_parser():
         )
     # Most commands take an arbitrary list of SARIF files or directories
     for cmd in _COMMANDS:
-        if cmd not in ["diff", "usage"]:
+        if cmd not in ["diff", "upgrade-filter", "usage"]:
             subparser[cmd].add_argument(
                 "files_or_dirs",
                 metavar="file_or_dir",
@@ -212,6 +212,16 @@ def _create_arg_parser():
         default="dmy",
         help="Date component order to use in output CSV.  Default is `dmy`",
     )
+
+    subparser["upgrade-filter"].add_argument(
+        "files_or_dirs",
+        metavar="file",
+        type=str,
+        nargs="*",
+        default=["."],
+        help="A v1-style blame-filter file",
+    )
+
     return parser
 
 
@@ -503,7 +513,7 @@ _COMMANDS = {
     },
     "upgrade-filter": {
         "fn": _upgrade_filter,
-        "desc": "Upgrade a v1-style blame filter file to a v2-style filter YAML file",
+        "desc": "Upgrade a sarif-tools v1-style blame filter file to a v2-style filter YAML file",
     },
     "usage": {"fn": _usage, "desc": "(Command optional) - print usage and exit"},
     "word": {

--- a/sarif/cmdline/main.py
+++ b/sarif/cmdline/main.py
@@ -22,6 +22,7 @@ from sarif.operations import (
     ls_op,
     summary_op,
     trend_op,
+    upgrade_filter_op,
     word_op,
 )
 
@@ -30,7 +31,7 @@ def main():
     """
     Entry point function.
     """
-    args = ARG_PARSER.parse_args()
+    args, unknown_args = ARG_PARSER.parse_known_args()
 
     if args.debug:
         print(f"SARIF tools v{SARIF_TOOLS_PACKAGE_VERSION}")
@@ -39,6 +40,19 @@ def main():
             f"{key}={getattr(args, key)}" for key in vars(args)
         )
         print(f"Known arguments: {known_args_summary}")
+
+    if unknown_args:
+        if any(
+            unknown_arg.startswith("--blame-filter")
+            or unknown_arg.startswith("-b=")
+            or unknown_arg == "-b"
+            for unknown_arg in unknown_args
+        ):
+            print("ERROR: --blame-filter was removed in v2.0.0.")
+            print(
+                "Run the upgrade-filter command to convert your blame filter to the new filter format, then pass via --filter option."
+            )
+        args = ARG_PARSER.parse_args()
 
     exitcode = args.func(args)
     return exitcode
@@ -84,7 +98,16 @@ def _create_arg_parser():
         + "(or for diff, an increase in issues at that level).",
     )
 
-    for cmd in ["blame", "codeclimate", "csv", "html", "emacs", "summary", "word"]:
+    for cmd in [
+        "blame",
+        "codeclimate",
+        "csv",
+        "html",
+        "emacs",
+        "summary",
+        "word",
+        "upgrade-filter",
+    ]:
         subparser[cmd].add_argument(
             "--output", "-o", type=str, metavar="PATH", help="Output file or directory"
         )
@@ -391,6 +414,27 @@ def _trend(args):
     return _check(input_files, args.check)
 
 
+def _upgrade_filter(args):
+    old_filter_files = args.files_or_dirs
+    single_output_file = None
+    output_dir = None
+    if len(old_filter_files) == 1:
+        if args.output and os.path.isdir(args.output):
+            output_dir = args.output
+        else:
+            single_output_file = args.output or old_filter_files[0] + ".yaml"
+    elif args.output:
+        output_dir = args.output
+    else:
+        output_dir = os.path.dirname(args.output)
+    for old_filter_file in old_filter_files:
+        output_file = single_output_file or os.path.join(
+            output_dir, os.path.basename(old_filter_file) + ".yaml"
+        )
+        upgrade_filter_op.upgrade_filter_file(old_filter_file, output_file)
+    return 0
+
+
 def _usage(args):
     if hasattr(args, "output") and args.output:
         with open(args.output, "w", encoding="utf-8") as file_out:
@@ -456,6 +500,10 @@ _COMMANDS = {
         "fn": _trend,
         "desc": "Write a CSV file with time series data from SARIF files with "
         '"yyyymmddThhmmssZ" timestamps in their filenames',
+    },
+    "upgrade-filter": {
+        "fn": _upgrade_filter,
+        "desc": "Upgrade a v1-style blame filter file to a v2-style filter YAML file",
     },
     "usage": {"fn": _usage, "desc": "(Command optional) - print usage and exit"},
     "word": {

--- a/sarif/filter/filter_stats.py
+++ b/sarif/filter/filter_stats.py
@@ -18,6 +18,7 @@ class FilterStats:
         self.filtered_in_result_count = 0
         self.filtered_out_result_count = 0
         self.missing_property_count = 0
+        self.unconvincing_line_number_count = 0
 
     def reset_counters(self):
         """
@@ -27,6 +28,7 @@ class FilterStats:
         self.filtered_in_result_count = 0
         self.filtered_out_result_count = 0
         self.missing_property_count = 0
+        self.unconvincing_line_number_count = 0
 
     def add(self, other_filter_stats):
         """
@@ -42,6 +44,9 @@ class FilterStats:
                 other_filter_stats.filtered_out_result_count
             )
             self.missing_property_count += other_filter_stats.missing_property_count
+            self.unconvincing_line_number_count += (
+                other_filter_stats.unconvincing_line_number_count
+            )
 
     def __str__(self):
         """
@@ -61,6 +66,11 @@ class FilterStats:
             f": {self.filtered_out_result_count} filtered out, "
             f"{self.filtered_in_result_count} passed the filter"
         )
+        if self.unconvincing_line_number_count:
+            ret += (
+                f", {self.unconvincing_line_number_count} included by default "
+                "for lacking line number information"
+            )
         if self.missing_property_count:
             ret += (
                 f", {self.missing_property_count} included by default "
@@ -80,6 +90,7 @@ class FilterStats:
             "out": self.filtered_out_result_count,
             "default": {
                 "noProperty": self.missing_property_count,
+                "noLineNumber": self.unconvincing_line_number_count,
             },
         }
 
@@ -95,5 +106,7 @@ def load_filter_stats_from_json(json_data):
         ret.rehydrated = True
         ret.filtered_in_result_count = json_data.get("in", 0)
         ret.filtered_out_result_count = json_data.get("out", 0)
-        ret.missing_property_count = json_data.get("default", {}).get("noProperty", 0)
+        default_stats = json_data.get("default", {})
+        ret.unconvincing_line_number_count = default_stats.get("noLineNumber", 0)
+        ret.missing_property_count = default_stats.get("noProperty", 0)
     return ret

--- a/sarif/loader.py
+++ b/sarif/loader.py
@@ -33,7 +33,7 @@ def load_sarif_files(*args) -> SarifFileSet:
                     if _add_path_to_sarif_file_set(resolved_path, ret):
                         path_exists = True
             if not path_exists:
-                print(f"Warning: path {path} not found")
+                print(f"Warning: input path {path} not found")
     return ret
 
 

--- a/sarif/operations/diff_op.py
+++ b/sarif/operations/diff_op.py
@@ -105,21 +105,21 @@ def _find_new_occurrences(new_records, old_records, issue_code_and_desc):
     ]
     new_occurrences_new_locations = []
     new_occurrences_new_lines = []
-    for r in new_records:
-        if sarif_file.combine_code_and_description(r) == issue_code_and_desc:
+    for new_record in new_records:
+        if sarif_file.combine_code_and_description(new_record) == issue_code_and_desc:
             (new_location, new_line) = (True, True)
-            for old_r in old_occurrences:
-                if old_r["Location"] == r["Location"]:
+            for old_record in old_occurrences:
+                if old_record["Location"] == new_record["Location"]:
                     new_location = False
-                    if old_r["Line"] == r["Line"]:
+                    if old_record["Line"] == new_record["Line"]:
                         new_line = False
                         break
             if new_location:
-                if r not in new_occurrences_new_locations:
-                    new_occurrences_new_locations.append(r)
+                if new_record not in new_occurrences_new_locations:
+                    new_occurrences_new_locations.append(new_record)
             elif new_line:
-                if r not in new_occurrences_new_lines:
-                    new_occurrences_new_lines.append(r)
+                if new_record not in new_occurrences_new_lines:
+                    new_occurrences_new_lines.append(new_record)
 
     return sorted(
         new_occurrences_new_locations, key=_record_to_location_tuple

--- a/sarif/operations/upgrade_filter_op.py
+++ b/sarif/operations/upgrade_filter_op.py
@@ -58,7 +58,7 @@ def upgrade_filter_file(old_filter_file, output_file):
         "description": filter_description
         if filter_description
         else f"Migrated from {os.path.basename(old_filter_file)}",
-        "configuration": {"default-include": True},
+        "configuration": {"default-include": True, "check-line-number": True},
     }
     if include_patterns:
         new_filter_definition["include"] = [
@@ -68,6 +68,6 @@ def upgrade_filter_file(old_filter_file, output_file):
         new_filter_definition["exclude"] = [
             {"author-mail": exclude_pattern} for exclude_pattern in exclude_patterns
         ]
-    with open(output_file, "wb") as yaml_out:
+    with open(output_file, "w", encoding="utf8") as yaml_out:
         yaml.dump(new_filter_definition, yaml_out)
     print("Wrote", output_file)

--- a/sarif/operations/upgrade_filter_op.py
+++ b/sarif/operations/upgrade_filter_op.py
@@ -1,0 +1,73 @@
+"""
+Code for `sarif upgrade-filter` command.
+"""
+
+import os
+import yaml
+
+
+def _load_blame_filter_file(file_path):
+    filter_description = os.path.basename(file_path)
+    include_patterns = []
+    exclude_patterns = []
+    try:
+        with open(file_path, encoding="utf-8") as file_in:
+            for line in file_in.readlines():
+                if line.startswith("\ufeff"):
+                    # Strip byte order mark
+                    line = line[1:]
+                lstrip = line.strip()
+                if lstrip.startswith("#"):
+                    # Ignore comment lines
+                    continue
+                pattern_spec = None
+                is_include = True
+                if lstrip.startswith("description:"):
+                    filter_description = lstrip[12:].strip()
+                elif lstrip.startswith("+: "):
+                    is_include = True
+                    pattern_spec = lstrip[3:].strip()
+                elif lstrip.startswith("-: "):
+                    is_include = False
+                    pattern_spec = lstrip[3:].strip()
+                else:
+                    is_include = True
+                    pattern_spec = lstrip
+                if pattern_spec:
+                    (include_patterns if is_include else exclude_patterns).append(
+                        pattern_spec
+                    )
+    except UnicodeDecodeError as error:
+        raise IOError(
+            f"Cannot read blame filter file {file_path}: not UTF-8 encoded?"
+        ) from error
+    return (
+        filter_description,
+        include_patterns,
+        exclude_patterns,
+    )
+
+
+def upgrade_filter_file(old_filter_file, output_file):
+    (
+        filter_description,
+        include_patterns,
+        exclude_patterns,
+    ) = _load_blame_filter_file(old_filter_file)
+    new_filter_definition = {
+        "description": filter_description
+        if filter_description
+        else f"Migrated from {os.path.basename(old_filter_file)}",
+        "configuration": {"default-include": True},
+    }
+    if include_patterns:
+        new_filter_definition["include"] = [
+            {"author-mail": include_pattern} for include_pattern in include_patterns
+        ]
+    if exclude_patterns:
+        new_filter_definition["exclude"] = [
+            {"author-mail": exclude_pattern} for exclude_pattern in exclude_patterns
+        ]
+    with open(output_file, "wb") as yaml_out:
+        yaml.dump(new_filter_definition, yaml_out)
+    print("Wrote", output_file)

--- a/sarif/sarif_file_utils.py
+++ b/sarif/sarif_file_utils.py
@@ -1,0 +1,43 @@
+"""
+Reusable utility functions for handling the SARIF format.
+
+Primarily interrogating the `result` JSON defined at
+https://docs.oasis-open.org/sarif/sarif/v2.1.0/cs01/sarif-v2.1.0-cs01.html#_Toc16012594
+"""
+
+from typing import Tuple
+
+
+def read_result_location(result) -> Tuple[str, str]:
+    """
+    Extract the file path and line number strings from the Result.
+
+    Tools store this in different ways, so this function tries a few different JSON locations.
+    """
+    file_path = None
+    line_number = None
+    locations = result.get("locations", [])
+    if locations and isinstance(locations, list):
+        location = locations[0]
+        physical_location = location.get("physicalLocation", {})
+        # SpotBugs has some errors with no line number so deal with them by just leaving it at 1
+        line_number = physical_location.get("region", {}).get("startLine", None)
+        # For file name, first try the location written by DevSkim
+        file_path = (
+            location.get("physicalLocation", {})
+            .get("address", {})
+            .get("fullyQualifiedName", None)
+        )
+        if not file_path:
+            # Next try the physical location written by MobSF and by SpotBugs (for some errors)
+            file_path = (
+                location.get("physicalLocation", {})
+                .get("artifactLocation", {})
+                .get("uri", None)
+            )
+        if not file_path:
+            logical_locations = location.get("logicalLocations", None)
+            if logical_locations:
+                # Finally, try the logical location written by SpotBugs for some errors
+                file_path = logical_locations[0].get("fullyQualifiedName", None)
+    return (file_path, line_number)

--- a/tests/test_general_filter.py
+++ b/tests/test_general_filter.py
@@ -1,5 +1,5 @@
 import pytest
-from sarif.filter.general_filter import GeneralFilter, load_filter_file
+from sarif.filter.general_filter import GeneralFilter, PropertyFilter, load_filter_file
 from sarif.filter.filter_stats import load_filter_stats_from_json
 
 
@@ -14,10 +14,27 @@ class TestGeneralFilter:
             [{"suppression": "not a suppression"}],
         )
         assert gf.filter_stats.filter_description == "test filter"
-        assert gf.include_filters == [{"author": "John Doe"}]
+        assert len(gf.include_filters[0].and_terms) == 1
+        assert gf.include_filters[0].and_terms[0].prop_path == "author"
         assert gf.apply_inclusion_filter is True
-        assert gf.exclude_filters == [{"suppression": "not a suppression"}]
+        assert len(gf.exclude_filters[0].and_terms) == 1
+        assert gf.exclude_filters[0].and_terms[0].prop_path == "suppression"
         assert gf.apply_exclusion_filter is True
+
+    def test_init_filter_no_value(self):
+        gf = GeneralFilter()
+
+        gf.init_filter(
+            "test filter",
+            {},
+            [{"author": {"default-include": False}}],  # forgot "value"
+            [],
+        )
+        assert gf.filter_stats.filter_description == "test filter"
+        assert len(gf.include_filters[0].and_terms) == 1
+        assert gf.include_filters[0].and_terms[0].prop_path == "author"
+        assert gf.apply_inclusion_filter is True
+        assert not gf.exclude_filters
 
     def test_rehydrate_filter_stats(self):
         gf = GeneralFilter()

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -2,4 +2,4 @@ import sarif
 
 
 def test_version():
-    assert sarif.__version__ == '1.0.0'
+    assert sarif.__version__ == "1.0.0"


### PR DESCRIPTION
Add an operation to upgrade old blame filters to new general YAML filters

As part of testing this, I remembered why we had the old "unconvincing line number" condition applied to the filtering.  The reason is that some static analysis tools record line number `"1"` for whole-file issues, but it's wrong to apply blame filtering based on who changed line number 1.  I've reinstated this using the new configuration framework, defaulting to true.

Fixes #31