### PR TITLE
Fix test_version test

### DIFF
--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -2,4 +2,4 @@ import sarif
 
 
 def test_version():
-    assert sarif.__version__ == "1.0.0"
+    assert sarif.__version__ == "2.0.0"


### PR DESCRIPTION
Hi :)

While packaging sarif-tools for NixOS, I noticed the `test_version` test fails because it expects `1.0.0` while the current version is `2.0.0`. Here's an update for the test.

```
============================= test session starts ==============================
platform linux -- Python 3.11.6, pytest-7.4.3, pluggy-1.3.0
rootdir: /build/source
collected 30 items                                                             

tests/test_general_filter.py .............................               [ 96%]
tests/test_version.py F                                                  [100%]

=================================== FAILURES ===================================
_________________________________ test_version _________________________________

    def test_version():
>       assert sarif.__version__ == "1.0.0"
E       AssertionError: assert '2.0.0' == '1.0.0'
E         - 1.0.0
E         ? ^
E         + 2.0.0
E         ? ^

tests/test_version.py:5: AssertionError
=========================== short test summary info ============================
FAILED tests/test_version.py::test_version - AssertionError: assert '2.0.0' == '1.0.0'
```