### PR TITLE
Make "invocation" an object per spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Made issue sorting and grouping more consistent across the various reports.
 - Multiple occurrences of a single issue are now sorted by location in the Word report.
 - Improved debug and version reporting for when multiple versions are installed.
+- For the copy operation, "invocation" in the resulting sarif is changed to an object to match the spec.
 
 ### Compatibility
 

--- a/sarif/operations/copy_op.py
+++ b/sarif/operations/copy_op.py
@@ -60,7 +60,9 @@ def generate_sarif(
                         "properties": conversion_properties,
                     }
                 },
-                "invocation": cmdline,
+                "invocation": {
+                    "commandLine": cmdline,
+                },
             }
             results = input_run.get_results()
             filter_stats = input_run.get_filter_stats()


### PR DESCRIPTION
The spec states "invocation" is an object, not a string: https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/sarif-v2.1.0-errata01-os-complete.html#_Toc141790817

This broke some parsing by other tools/libs.