### PR TITLE
Avoid word wrap crash when issue code long

### DIFF
--- a/sarif/sarif_file_utils.py
+++ b/sarif/sarif_file_utils.py
@@ -23,7 +23,9 @@ def combine_code_and_description(code: str, description: str) -> str:
         code = code.strip()
         length_budget -= len(code) + 1
     # Allow extra space when truncating for continuation characters
-    length_budget_pre_continuation = length_budget - 20
+    length_budget_pre_continuation = length_budget - 5
+    if length_budget_pre_continuation < 10:
+        return code
     if description:
         if "\n" in description:
             description = description[: description.index("\n")]
@@ -33,7 +35,7 @@ def combine_code_and_description(code: str, description: str) -> str:
             shorter_description = textwrap.shorten(
                 description, width=length_budget_pre_continuation, placeholder=" ..."
             )
-            if len(shorter_description) < 40:
+            if len(shorter_description) < length_budget_pre_continuation - 40:
                 description = description[:length_budget_pre_continuation] + " ..."
             else:
                 description = shorter_description
@@ -41,7 +43,7 @@ def combine_code_and_description(code: str, description: str) -> str:
             return f"{code.strip()} {description}"
         return description
     if code:
-        return code.strip()
+        return code
     return "<NONE>"
 
 

--- a/sarif/sarif_file_utils.py
+++ b/sarif/sarif_file_utils.py
@@ -21,10 +21,12 @@ def combine_code_and_description(code: str, description: str) -> str:
     length_budget = 120
     if code:
         code = code.strip()
-        length_budget -= len(code) + 1
+        length_budget -= len(code) + 1  # Allow issue code and space character
+    continuation_placeholder = " ..."
     # Allow extra space when truncating for continuation characters
-    length_budget_pre_continuation = length_budget - 5
+    length_budget_pre_continuation = length_budget - len(continuation_placeholder)
     if length_budget_pre_continuation < 10:
+        # Don't include description if it would be very short due to long code
         return code
     if description:
         if "\n" in description:
@@ -33,10 +35,16 @@ def combine_code_and_description(code: str, description: str) -> str:
     if description:
         if len(description) > length_budget:
             shorter_description = textwrap.shorten(
-                description, width=length_budget_pre_continuation, placeholder=" ..."
+                description,
+                width=length_budget_pre_continuation,
+                placeholder=continuation_placeholder,
             )
             if len(shorter_description) < length_budget_pre_continuation - 40:
-                description = description[:length_budget_pre_continuation] + " ..."
+                # Word wrap shortens the description significantly, so truncate mid-word instead
+                description = (
+                    description[:length_budget_pre_continuation]
+                    + continuation_placeholder
+                )
             else:
                 description = shorter_description
         if code:

--- a/tests/test_sarif_file_utils.py
+++ b/tests/test_sarif_file_utils.py
@@ -1,12 +1,15 @@
 from sarif import sarif_file_utils
 
 
-def test_combine_code_and_description():
+def test_combine_code_and_description_short():
     cd = sarif_file_utils.combine_code_and_description(
         "ABC123", "Some short description"
     )
     assert cd == "ABC123 Some short description"
     assert len(cd) <= 120
+
+
+def test_combine_code_and_description_long_desc():
     cd = sarif_file_utils.combine_code_and_description(
         "ABC123", " ".join(f"blah{i}" for i in range(1, 30))
     )
@@ -15,10 +18,13 @@ def test_combine_code_and_description():
         == "ABC123 blah1 blah2 blah3 blah4 blah5 blah6 blah7 blah8 blah9 blah10 blah11 blah12 blah13 blah14 blah15 blah16 ..."
     )
     assert len(cd) <= 120
+
+
+def test_combine_code_and_description_long_code():
     long_code = "".join(f"A{i}" for i in range(1, 36)) + "BC"
     assert (
         len(long_code) == 98
-    ), "98 is right length to hit'placeholder too large for max width' without defensive code"
+    ), "98 is right length to hit 'placeholder too large for max width' without defensive code"
     cd = sarif_file_utils.combine_code_and_description(
         long_code, "wow that's a long code"
     )

--- a/tests/test_sarif_file_utils.py
+++ b/tests/test_sarif_file_utils.py
@@ -1,0 +1,31 @@
+from sarif import sarif_file_utils
+
+
+def test_combine_code_and_description():
+    cd = sarif_file_utils.combine_code_and_description(
+        "ABC123", "Some short description"
+    )
+    assert cd == "ABC123 Some short description"
+    assert len(cd) <= 120
+    cd = sarif_file_utils.combine_code_and_description(
+        "ABC123", " ".join(f"blah{i}" for i in range(1, 30))
+    )
+    assert (
+        cd
+        == "ABC123 blah1 blah2 blah3 blah4 blah5 blah6 blah7 blah8 blah9 blah10 blah11 blah12 blah13 blah14 blah15 blah16 ..."
+    )
+    assert len(cd) <= 120
+    long_code = "".join(f"A{i}" for i in range(1, 36)) + "BC"
+    assert (
+        len(long_code) == 98
+    ), "98 is right length to hit'placeholder too large for max width' without defensive code"
+    cd = sarif_file_utils.combine_code_and_description(
+        long_code, "wow that's a long code"
+    )
+    assert cd == f"{long_code} wow that's a ..."
+    assert len(cd) <= 120
+    long_code = "".join(f"A{i}" for i in range(1, 50))
+    cd = sarif_file_utils.combine_code_and_description(
+        long_code, "wow that's a long code"
+    )
+    assert cd == long_code


### PR DESCRIPTION
Add defensive code to avoid trying to run word wrap when there is not enough space on the line due to long issue code.  Also added unit test for this function `combine_code_and_description` that reproduced the issue.

Fixes #51 