### PR TITLE
Sanitise file URIs for git blame

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Multiple occurrences of a single issue are now sorted by location in the Word report.
 - Improved debug and version reporting for when multiple versions are installed.
 - For the copy operation, "invocation" in the resulting sarif is changed to an object to match the spec.
+- #53 Fix the `blame` command for `file:///` URL locations.
 
 ### Compatibility
 

--- a/sarif/operations/blame_op.py
+++ b/sarif/operations/blame_op.py
@@ -6,6 +6,7 @@ import json
 import os
 import subprocess
 import sys
+import urllib.request
 
 from sarif.sarif_file import SarifFileSet
 
@@ -94,10 +95,16 @@ def _enhance_with_blame(input_files, repo_path):
     print(f"Found blame information for {blame_info_count} of {item_count} results")
 
 
+def _make_path_git_compatible(file_path):
+    if file_path.startswith("file://"):
+        return urllib.request.url2pathname(file_path[7:])
+    return file_path
+
+
 def _run_git_blame_on_files(files_to_blame, repo_path):
     file_blame_info = {}
     for file_path in files_to_blame:
-        cmd = ["git", "blame", "--porcelain", file_path]
+        cmd = ["git", "blame", "--porcelain", _make_path_git_compatible(file_path)]
         with subprocess.Popen(cmd, stdout=subprocess.PIPE, cwd=repo_path) as proc:
             blame_info = {"commits": {}, "line_to_commit": {}}
             file_blame_info[file_path] = blame_info


### PR DESCRIPTION
`git blame` doesn't recognise `file://` URIs as paths inside the repository, so sarif-tools needs to turn them into normal file paths.  This change makes the `sarif blame` command do that, using the stdlib [url2pathname](https://docs.python.org/3/library/urllib.request.html#urllib.request.url2pathname) API.

Fixes #53 