### PR TITLE
Fix regression in diff command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.0.0](releases/tag/v3.0.0) - Unreleased
+## [3.0.0](releases/tag/v3.0.0) - 2024-09-10
 
 ### Breaking Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.1] - unreleased
+
+### Fixed
+
+- #58 Fixed regression that broke `sarif diff` command in v3.0.0.
+
 ## [3.0.0](releases/tag/v3.0.0) - 2024-09-10
 
 ### Breaking Changes

--- a/README.md
+++ b/README.md
@@ -799,7 +799,7 @@ There are three levels of normalisation and aggregation of the results from the 
    `sarif_file.BASIC_RECORD_ATTRIBUTES`:
     - `"Tool"` - the tool name for the run containing the result.
     - `"Severity"` - the SARIF severity for the record.  One of `error`, `warning` (the default if the
-      record doesn't specify) or `note`.
+      record doesn't specify), `note` or `none`.
     - `"Code"` - the issue code from the result.
     - `"Description"` - the issue name from the result - corresponding to the Code.
     - `"Location"` - the location of the issue, typically the file containing the issue.  Format varies
@@ -823,6 +823,9 @@ A `SarifRun` has a single tool name so the equivalent method is `get_tool_name()
   - Return the list of SARIF result objects as dicts - see above.
 - `get_records()`
   - Return the list of SARIF records as flat dicts - see above.
+- `get_report()`
+  - Return the `IssuesReport` object that groups the records by issue type and sorts them by
+    location.
 
 ### Key methods on `IssuesReport`
 
@@ -844,9 +847,10 @@ The key methods on the `IssuesReport` are:
   report, get the list of severities and then iterate through them calling other methods to get the
   summary of results at that severity level in the required form.
 - `any_none_severities()`: `True` or `False` that there are any records with severity `none`.
-  This is not used by many tools, so it is only included as a heading if there are any matching
-  records, to avoid a redundant `none` header otherwise.  Severities `error`, `warning` and `note`
-  are always included even if no records, as these levels are all relevant for issues.
+  Severity `none` is not used by many tools, so it is only included as a heading if there are any
+  matching records, to avoid a redundant and potentially-confusing `none` header otherwise.
+  Severities `error`, `warning` and `note` are always included even if no records, as these levels
+  are all relevant for static analysis issues.
 - `get_issue_count_for_severity(severity)`: Get the total number of results at this severity.
 - `get_issue_type_count_for_severity(severity)`:  Get the total number of issue types at this severity.
 - `get_issues_grouped_by_type_for_severity(severity)`: Get a dict from issue type key (code + description)

--- a/README.md
+++ b/README.md
@@ -81,6 +81,32 @@ installations, or the `python` installation on the super-user's `PATH` is differ
 in normal CMD and Admin CMD to see which installations are in use; on Linux, it's `which python` and
 `which pip` with and without `sudo`.
 
+## File format variations
+
+SARIF is a standard format for the output of static analysis tools, but as always, different tools
+use the standard in different ways.  The key parts of the spec that the SARIF Tools look at are:
+
+- Severity: Only `error`, `warning`, `note` and `none` are allowed by the SARIF standard.
+- Code and message: Issue types should have a short code and a short name, called "message" in the
+  standard and usually called "description" in Sarif-Tools.
+- Location: A specific location where the issue occurred, normally a file path and a line number.
+
+Static analysis tools often have different ideas from the SARIF standard about how to represent
+these pieces of data, and tool authors make different levels of effort to map their output to the
+SARIF standard.  Examples we have seen are:
+
+- Only using one SARIF severity level, and putting the "real" severity level into a custom property.
+- Including the location information in the message, so that the same issue in different locations
+  has a different message.
+- Representing the location in different ways.
+
+The Sarif-Tools code applies some minor fudging to produce decent results for mildly-divergent
+tools.  For example, issue types are identified by a combination of code and truncated message,
+either of which is allowed to be absent.  However, if Sarif-Tools is producing bad results for a
+specific tool, you may need to implement custom pre-processing of the SARIF output, or ask the
+tool authors to improve the quality of their tool's SARIF output to better align to the standard,
+or [raise an issue against Sarif-Tools](https://github.com/microsoft/sarif-tools/issues).
+
 ## Command Line Usage
 
 ```plain
@@ -754,54 +780,82 @@ report = sarif_data.get_report()
 error_histogram = report.get_issue_type_histogram_for_severity("error")
 ```
 
-### Result access API
+### Files and file sets
 
 The three classes defined in the `sarif_files` module, `SarifFileSet`, `SarifFile` and `SarifRun`,
 provide similar APIs, which allows SARIF results to be handled similarly at multiple levels of
-aggregation.  This section briefly describes some of the key APIs at the three levels of
-aggregation.
+aggregation.  To explore the results, use `get_report()`.
 
-#### get_distinct_tool_names()
+### Results, records and reports
 
-Returns a list of distinct tool names in a `SarifFile` or for all files in a `SarifFileSet`.
+There are three levels of normalisation and aggregation of the results from the SARIF files:
+
+1. Results, obtained from the `SarifFileSet`, `SarifFile` or `SarifRun` via the `get_results()`
+   method.  These are dicts directly deserialised from the JSON Result objects in the SARIF data,
+   as defined in the
+   [SARIF standard section 3.27](https://docs.oasis-open.org/sarif/sarif/v2.1.0/os/sarif-v2.1.0-os.html#_Toc34317638).
+2. Records, obtained from the `SarifFileSet`, `SarifFile` or `SarifRun` via the `get_records()`
+   method.  Each record is a flat dict of key-value pairs where the keys are those in
+   `sarif_file.BASIC_RECORD_ATTRIBUTES`:
+    - `"Tool"` - the tool name for the run containing the result.
+    - `"Severity"` - the SARIF severity for the record.  One of `error`, `warning` (the default if the
+      record doesn't specify) or `note`.
+    - `"Code"` - the issue code from the result.
+    - `"Description"` - the issue name from the result - corresponding to the Code.
+    - `"Location"` - the location of the issue, typically the file containing the issue.  Format varies
+      by tool.
+    - `"Line"` - the line number in the file where the issue occurs.  Value is a string.  This defaults
+      to `"1"` if the tool failed to identify the line.
+   This flat list of records is useful for machine-readable output formats like CSV.
+3. Reports are `IssuesReport` objects, as defined in the `issues_report.py`.  Reports group and
+   sort records to provide a useful structure for human-readable output formats like Word and HTML.
+   The report can be obtained from the `SarifFileSet`, `SarifFile` or `SarifRun` via the
+   `get_report()` method.
+
+### Key methods on Files and file sets
+
+These methods exist across `SarifFileSet`, `SarifFile` and `SarifRun`.
+
+- `get_distinct_tool_names()`
+  - Returns a list of distinct tool names in a `SarifFile` or for all files in a `SarifFileSet`.
 A `SarifRun` has a single tool name so the equivalent method is `get_tool_name()`.
+- `get_results()`
+  - Return the list of SARIF result objects as dicts - see above.
+- `get_records()`
+  - Return the list of SARIF records as flat dicts - see above.
 
-#### get_results()
+### Key methods on `IssuesReport`
 
-Return the list of SARIF results.  These are objects as defined in the
-[SARIF standard section 3.27](https://docs.oasis-open.org/sarif/sarif/v2.1.0/os/sarif-v2.1.0-os.html#_Toc34317638).
+The `IssuesReport` provides methods that group issues in three levels:
 
-#### get_records()
+1. Severity: SARIF defines severity levels `error`, `warning` and `note`, plus `none` which is
+   sometimes used when the results in the SARIF file are not issues.
+2. Issue Type: SARIF Results are identified by code, description or a combination of the two.
+   The same issue can occur in multiple locations, so the `IssuesReport` groups these together
+   per issue type, within a given severity level.  The issue type code key is formed by combining
+   the issue code and issue description, with a space character inserted in-between, but truncated
+   to be shorter than 120 characters.
+3. Record: The individual records under an issue type represent the locations where that issue
+   occurs.  They are sorted into a sensible location order.
 
-Return the list of SARIF results as simplified, flattened record dicts.  Each record has the
-attributes defined in `sarif_file.RECORD_ATTRIBUTES`.
+The key methods on the `IssuesReport` are:
 
-- `"Tool"` - the tool name for the run containing the result.
-- `"Severity"` - the SARIF severity for the record.  One of `error`, `warning` (the default if the
-  record doesn't specify) or `note`.
-- `"Code"` - the issue code from the result.
-- `"Description"` - the issue name from the result - corresponding to the Code.
-- `"Location"` - the location of the issue, typically the file containing the issue.  Format varies
-  by tool.
-- `"Line"` - the line number in the file where the issue occurs.  Value is a string.  This defaults
-  to `"1"` if the tool failed to identify the line.
-
-#### get_records_grouped_by_severity()
-
-As per `get_records()`, but the result is a dict from SARIF severity level (`error`, `warning` and
-`note`) to the list of records of that severity level.
-
-#### get_result_count(), get_result_count_by_severity()
-
-Get the total number of SARIF results.  `get_result_count_by_severity()` returns a dict from
-SARIF severity level (`error`, `warning` and `note`) to the integer number of results of that
-severity.
-
-#### get_issue_code_histogram(severity)
-
-For the given severity, get histogram in the form of a list of pairs.  The first item in each pair
-is the issue code, the second item is the number of matching records, and the list is sorted in
-decreasing order of frequency (the same as the `sarif summary` command output).
+- `get_severities()`: Get the ordered list of severities, from worst to least bad.  To render a
+  report, get the list of severities and then iterate through them calling other methods to get the
+  summary of results at that severity level in the required form.
+- `any_none_severities()`: `True` or `False` that there are any records with severity `none`.
+  This is not used by many tools, so it is only included as a heading if there are any matching
+  records, to avoid a redundant `none` header otherwise.  Severities `error`, `warning` and `note`
+  are always included even if no records, as these levels are all relevant for issues.
+- `get_issue_count_for_severity(severity)`: Get the total number of results at this severity.
+- `get_issue_type_count_for_severity(severity)`:  Get the total number of issue types at this severity.
+- `get_issues_grouped_by_type_for_severity(severity)`: Get a dict from issue type key (code + description)
+  to the sorted list of results of that type.
+- `get_issue_type_histogram_for_severity(severity)`: Get a dict from issue type key (code + description)
+  to the number of results of that type.
+- `get_issues_for_severity(severity)`: Get a flat list of results at the given severity.  This is
+  like the result of `get_issues_grouped_by_type_for_severity` but flattened from a `dict[str, list]`
+  to a single `list` in the same order as the original sequence of lists.
 
 #### Disaggregation and filename access
 

--- a/sarif/cmdline/main.py
+++ b/sarif/cmdline/main.py
@@ -347,11 +347,11 @@ def _csv_command(args):
 
 
 def _diff_command(args):
-    original_sarif = loader.load_sarif_files(args.old_file_or_dir[0])
+    old_sarif = loader.load_sarif_files(args.old_file_or_dir[0])
     new_sarif = loader.load_sarif_files(args.new_file_or_dir[0])
-    _init_filtering(original_sarif, args)
+    _init_filtering(old_sarif, args)
     _init_filtering(new_sarif, args)
-    return diff_op.print_diff(original_sarif, new_sarif, args.output, args.check)
+    return diff_op.print_diff(old_sarif, new_sarif, args.output, args.check)
 
 
 def _html_command(args):

--- a/sarif/issues_report.py
+++ b/sarif/issues_report.py
@@ -65,7 +65,8 @@ class IssuesReport:
                                 break
             sorted_codes = sorted(
                 code_to_key_and_count.keys(),
-                key=lambda code: -code_to_key_and_count[code]["count"],
+                key=lambda code: code_to_key_and_count[code]["count"],
+                reverse=True,
             )
             self._sev_to_sorted_keys[severity] = {
                 code_to_key_and_count[code]["key"]: [] for code in sorted_codes

--- a/sarif/operations/diff_op.py
+++ b/sarif/operations/diff_op.py
@@ -7,7 +7,6 @@ import sys
 from typing import Dict
 
 from sarif import sarif_file
-from sarif.sarif_file_utils import combine_record_code_and_description
 
 
 def _occurrences(occurrence_count):
@@ -29,20 +28,23 @@ def print_diff(
     new_sarif: sarif_file.SarifFileSet,
     output,
     check_level=None,
-) -> str:
+) -> int:
     """
     Generate a diff of the issues from the SARIF files and write it to stdout
     or a file if specified.
-    original_sarif corresponds to the old files.
-    new_sarif corresponds to the new files.
+    :param original_sarif: corresponds to the old files.
+    :param new_sarif: corresponds to the new files.
+    :return: number of increased severities, or 0 if nothing has got worse.
     """
-    diff = calc_diff(original_sarif, new_sarif)
+    diff = _calc_diff(original_sarif, new_sarif)
     if output:
         print("writing diff to", output)
         with open(output, "w", encoding="utf-8") as output_file:
             json.dump(diff, output_file, indent=4)
     else:
         for severity in sarif_file.SARIF_SEVERITIES_WITH_NONE:
+            if severity not in diff:
+                continue
             if diff[severity]["codes"]:
                 print(
                     severity,
@@ -50,20 +52,20 @@ def print_diff(
                     _signed_change(diff[severity]["+"]),
                     _signed_change(-diff[severity]["-"]),
                 )
-                for issue_code, code_info in diff[severity]["codes"].items():
+                for issue_key, code_info in diff[severity]["codes"].items():
                     (old_count, new_count, new_locations) = (
                         code_info["<"],
                         code_info[">"],
                         code_info.get("+@", []),
                     )
                     if old_count == 0:
-                        print(f'  New issue "{issue_code}" ({_occurrences(new_count)})')
+                        print(f'  New issue "{issue_key}" ({_occurrences(new_count)})')
                     elif new_count == 0:
-                        print(f'  Eliminated issue "{issue_code}"')
+                        print(f'  Eliminated issue "{issue_key}"')
                     else:
                         print(
                             f"  Number of occurrences {old_count} -> {new_count}",
-                            f'({_signed_change(new_count - old_count)}) for issue "{issue_code}"',
+                            f'({_signed_change(new_count - old_count)}) for issue "{issue_key}"',
                         )
                     if new_locations:
                         # Print the top 3 new locations
@@ -98,69 +100,73 @@ def print_diff(
     return ret
 
 
-def _find_new_occurrences(new_records, old_records, issue_code_and_desc):
-    old_occurrences = [
-        r
-        for r in old_records
-        if combine_record_code_and_description(r) == issue_code_and_desc
-    ]
+def _find_new_occurrences(new_records, old_records):
+    old_occurrences = old_records
     new_occurrences_new_locations = []
     new_occurrences_new_lines = []
     for new_record in new_records:
-        if combine_record_code_and_description(new_record) == issue_code_and_desc:
-            (new_location, new_line) = (True, True)
-            for old_record in old_occurrences:
-                if old_record["Location"] == new_record["Location"]:
-                    new_location = False
-                    if old_record["Line"] == new_record["Line"]:
-                        new_line = False
-                        break
-            if new_location:
-                if new_record not in new_occurrences_new_locations:
-                    new_occurrences_new_locations.append(new_record)
-            elif new_line:
-                if new_record not in new_occurrences_new_lines:
-                    new_occurrences_new_lines.append(new_record)
+        (new_location, new_line) = (True, True)
+        for old_record in old_occurrences:
+            if old_record["Location"] == new_record["Location"]:
+                new_location = False
+                if old_record["Line"] == new_record["Line"]:
+                    new_line = False
+                    break
+        if new_location:
+            if new_record not in new_occurrences_new_locations:
+                new_occurrences_new_locations.append(new_record)
+        elif new_line:
+            if new_record not in new_occurrences_new_lines:
+                new_occurrences_new_lines.append(new_record)
 
     return sorted(
         new_occurrences_new_locations, key=_record_to_location_tuple
     ) + sorted(new_occurrences_new_lines, key=_record_to_location_tuple)
 
 
-def calc_diff(
+def _calc_diff(
     original_sarif: sarif_file.SarifFileSet, new_sarif: sarif_file.SarifFileSet
 ) -> Dict:
     """
     Generate a diff of the issues from the SARIF files.
     original_sarif corresponds to the old files.
     new_sarif corresponds to the new files.
-    Return dict has keys "error", "warning", "note" and "all".
+    Return dict has keys "error", "warning", "note", "none" (if present) and "all".
     """
     ret = {"all": {"+": 0, "-": 0}}
-    for severity in sarif_file.SARIF_SEVERITIES_WITH_NONE:
-        original_histogram = dict(original_sarif.get_issue_code_histogram(severity))
-        new_histogram = new_sarif.get_issue_code_histogram(severity)
-        new_histogram_dict = dict(new_histogram)
+    old_report = original_sarif.get_report()
+    new_report = new_sarif.get_report()
+    severities = (
+        old_report.get_severities()
+        if old_report.any_none_severities()
+        else new_report.get_severities()
+    )
+    for severity in severities:
+        original_histogram = old_report.get_issue_type_histogram_for_severity(severity)
+        new_histogram = new_report.get_issue_type_histogram_for_severity(severity)
         ret[severity] = {"+": 0, "-": 0, "codes": {}}
-        if original_histogram != new_histogram_dict:
-            for issue_code, count in new_histogram:
-                old_count = original_histogram.pop(issue_code, 0)
+        if original_histogram != new_histogram:
+            for issue_key, count in new_histogram.items():
+                old_count = original_histogram.pop(issue_key, 0)
                 if old_count != count:
-                    ret[severity]["codes"][issue_code] = {"<": old_count, ">": count}
+                    ret[severity]["codes"][issue_key] = {"<": old_count, ">": count}
                     if old_count == 0:
                         ret[severity]["+"] += 1
                     new_occurrences = _find_new_occurrences(
-                        new_sarif.get_records(),
-                        original_sarif.get_records(),
-                        issue_code,
+                        new_report.get_issues_grouped_by_type_for_severity(
+                            severity
+                        ).get(issue_key, []),
+                        old_report.get_issues_grouped_by_type_for_severity(
+                            severity
+                        ).get(issue_key, []),
                     )
                     if new_occurrences:
-                        ret[severity]["codes"][issue_code]["+@"] = [
+                        ret[severity]["codes"][issue_key]["+@"] = [
                             {"Location": r["Location"], "Line": r["Line"]}
                             for r in new_occurrences
                         ]
-            for issue_code, old_count in original_histogram.items():
-                ret[severity]["codes"][issue_code] = {"<": old_count, ">": 0}
+            for issue_key, old_count in original_histogram.items():
+                ret[severity]["codes"][issue_key] = {"<": old_count, ">": 0}
                 ret[severity]["-"] += 1
         ret["all"]["+"] += ret[severity]["+"]
         ret["all"]["-"] += ret[severity]["-"]

--- a/sarif/sarif_file.py
+++ b/sarif/sarif_file.py
@@ -549,10 +549,8 @@ class SarifFileSet:
         Iterate the SARIF files in this set.
         """
         for subdir in self.subdirs:
-            for input_file in subdir.files:
-                yield input_file
-        for input_file in self.files:
-            yield input_file
+            yield from subdir.files
+        yield from self.files
 
     def __getitem__(self, index) -> SarifFile:
         i = 0

--- a/sarif/sarif_file_utils.py
+++ b/sarif/sarif_file_utils.py
@@ -31,6 +31,9 @@ def combine_code_and_description(code: str, description: str) -> str:
     if description:
         if "\n" in description:
             description = description[: description.index("\n")]
+        if description.startswith(code):
+            # Don't duplicate the code
+            description = description[len(code) :]
         description = description.strip()
     if description:
         if len(description) > length_budget:

--- a/tests/test_diff_op.py
+++ b/tests/test_diff_op.py
@@ -1,0 +1,110 @@
+import json
+import os
+import tempfile
+
+from sarif.operations import diff_op
+from sarif import sarif_file
+
+SARIF_WITH_1_ISSUE = {
+    "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
+    "version": "2.1.0",
+    "runs": [
+        {
+            "tool": {"driver": {"name": "unit test"}},
+            "results": [
+                {
+                    "ruleId": "CA2101",
+                    "level": "error",
+                    "locations": [
+                        {
+                            "physicalLocation": {
+                                "artifactLocation": {
+                                    "uri": "file:///C:/Code/main.c",
+                                    "index": 0,
+                                },
+                                "region": {"startLine": 24, "startColumn": 9},
+                            }
+                        }
+                    ],
+                }
+            ],
+        }
+    ],
+}
+
+SARIF_WITH_2_ISSUES = {
+    "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
+    "version": "2.1.0",
+    "runs": [
+        {
+            "tool": {"driver": {"name": "unit test"}},
+            "results": [
+                {
+                    "ruleId": "CA2101",
+                    "level": "error",
+                    "locations": [
+                        {
+                            "physicalLocation": {
+                                "artifactLocation": {
+                                    "uri": "file:///C:/Code/main.c",
+                                    "index": 0,
+                                },
+                                "region": {"startLine": 24, "startColumn": 9},
+                            }
+                        }
+                    ],
+                },
+                {
+                    "ruleId": "CA2102",
+                    "level": "error",
+                    "locations": [
+                        {
+                            "physicalLocation": {
+                                "artifactLocation": {
+                                    "uri": "file:///C:/Code/main.c",
+                                    "index": 0,
+                                },
+                                "region": {"startLine": 34, "startColumn": 9},
+                            }
+                        }
+                    ],
+                },
+            ],
+            "columnKind": "utf16CodeUnits",
+        }
+    ],
+}
+
+
+def test_print_diff():
+    old_sarif = sarif_file.SarifFile("SARIF_WITH_1_ISSUE", SARIF_WITH_1_ISSUE)
+    new_sarif = sarif_file.SarifFile("SARIF_WITH_2_ISSUES", SARIF_WITH_2_ISSUES)
+    with tempfile.TemporaryDirectory() as tmp:
+        file_path = os.path.join(tmp, "diff.json")
+        result = diff_op.print_diff(
+            old_sarif, new_sarif, file_path, check_level="warning"
+        )
+        with open(file_path, "rb") as f_in:
+            diff_dict = json.load(f_in)
+        assert result == 1
+        assert diff_dict == {
+            "all": {"+": 1, "-": 0},
+            "error": {
+                "+": 1,
+                "-": 0,
+                "codes": {
+                    "CA2102": {
+                        "<": 0,
+                        ">": 1,
+                        "+@": [{"Location": "file:///C:/Code/main.c", "Line": 34}],
+                    }
+                },
+            },
+            "warning": {"+": 0, "-": 0, "codes": {}},
+            "note": {"+": 0, "-": 0, "codes": {}},
+        }
+        # If issues have decreased, return value should be 0.
+        assert (
+            diff_op.print_diff(new_sarif, old_sarif, file_path, check_level="warning")
+            == 0
+        )


### PR DESCRIPTION
v3.0.0 introduced the new `IssuesReport` class to consolidate summarisation logic that had been scattered across multiple operations.  However, we missed updating the `diff` command accordingly, so it broke.

I've also improved the documentation to describe `IssuesReport` and added a unit test that would have detected the regression.

Fixes #58 