### PR TITLE
Prevent Sarif-Tools-Release pipeline from running on PRs

### DIFF
--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -1,0 +1,10 @@
+name: Release
+trigger: none
+pr: none
+
+stages:
+  - stage: A
+    jobs:
+      - job: A1
+        steps:
+          - bash: echo "Hello world"


### PR DESCRIPTION
To enable testing of the new AzDO-based release pipeline, I added an empty `release.yml` a while back. The presence of the file was necessary to create the pipeline. However, it is currently running against all PRs, whereas it is intended to only run when kicked off manually or perhaps based on tag creation.

This PR adds a minimal chunk of YAML to prevent the pipeline from running in PRs. The `pr: none` at the top is the relevant bit. `trigger: none` tells it to not run on commits in main (CI) either. And the simple stages are required because all pipelines must have at least one stage, one job, and one step.