### PR TITLE
Add GitHub Actions for PR validation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,4 +34,10 @@ jobs:
 
       - uses: actions/upload-artifact@v3
         with:
-          path: dist/sarif_tools-${{ steps.get_version.outputs.releaseVersion }}*
+          name: wheel
+          path: dist/sarif_tools-${{ steps.get_version.outputs.releaseVersion }}-py3-none-any.whl
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: tarball
+          path: dist/sarif_tools-${{ steps.get_version.outputs.releaseVersion }}.tar.gz

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,9 +28,10 @@ jobs:
         run: poetry build --no-interaction
 
       - name: Get Verison
+        id: get_version
         shell: bash
         run: echo "releaseVersion=$(& poetry version --short)" >> $GITHUB_OUTPUT
 
       - uses: actions/upload-artifact@v3
         with:
-          path: dist/sarif_tools-$(releaseVersion)*
+          path: dist/sarif_tools-${{ steps.get_version.outputs.releaseVersion }}*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    if: github.repository == 'microsoft/sarif-tools'
+    # if: github.repository == 'microsoft/sarif-tools'
     runs-on: ubuntu-latest
     name: Build
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,37 @@
+name: Build
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    if: github.repository == 'microsoft/sarif-tools'
+    runs-on: ubuntu-latest
+    name: Build
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.8'
+
+      - name: Install Poetry
+        run: pip install poetry
+
+      - name: Poetry Build
+        run: poetry build --no-interaction
+
+      - name: Get Verison
+        shell: bash
+        run: echo "releaseVersion=$(& poetry version --short)" >> $GITHUB_OUTPUT
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: sarif_tools-$(releaseVersion)*
+          path: dist

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,5 +33,4 @@ jobs:
 
       - uses: actions/upload-artifact@v3
         with:
-          name: sarif_tools-$(releaseVersion)*
-          path: dist
+          path: dist/sarif_tools-$(releaseVersion)*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,8 +36,3 @@ jobs:
         with:
           name: wheel
           path: dist/sarif_tools-${{ steps.get_version.outputs.releaseVersion }}-py3-none-any.whl
-
-      - uses: actions/upload-artifact@v3
-        with:
-          name: tarball
-          path: dist/sarif_tools-${{ steps.get_version.outputs.releaseVersion }}.tar.gz

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Get Verison
         id: get_version
         shell: bash
-        run: echo "releaseVersion=$(& poetry version --short)" >> $GITHUB_OUTPUT
+        run: echo "releaseVersion=$(poetry version --short)" >> $GITHUB_OUTPUT
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    # if: github.repository == 'microsoft/sarif-tools'
+    if: github.repository == 'microsoft/sarif-tools'
     runs-on: ubuntu-latest
     name: Build
 

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   hygiene:
-    #if: github.repository == 'microsoft/sarif-tools'
+    if: github.repository == 'microsoft/sarif-tools'
     runs-on: ubuntu-latest
     name: Hygiene
     permissions:
@@ -31,7 +31,7 @@ jobs:
         run: poetry check
 
   test:
-    #if: github.repository == 'microsoft/sarif-tools'
+    if: github.repository == 'microsoft/sarif-tools'
     runs-on: ubuntu-latest
     name: Test
     steps:

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   hygiene:
-    if: github.repository == 'microsoft/sarif-tools'
+    #if: github.repository == 'microsoft/sarif-tools'
     runs-on: ubuntu-latest
     name: Hygiene
     permissions:

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -1,0 +1,31 @@
+name: Validation
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  hygiene:
+    if: github.repository == 'microsoft/sarif-tools'
+    runs-on: ubuntu-latest
+    name: Hygiene
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.8'
+
+      - name: Install Poetry
+        run: pip install poetry
+
+      - name: Validate pyproject.toml and poetry.lock
+        run: poetry check

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -29,3 +29,24 @@ jobs:
 
       - name: Validate pyproject.toml and poetry.lock
         run: poetry check
+
+  test:
+    #if: github.repository == 'microsoft/sarif-tools'
+    runs-on: ubuntu-latest
+    name: Test
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.8'
+
+      - name: Install Poetry
+        run: pip install poetry
+
+      - name: Install dependencies
+        run: poetry install --with dev
+
+      - name: Run tests
+        run: poetry run pytest


### PR DESCRIPTION
Added GitHub Actions to validate PRs. Failures in these actions will block the PR:
- `build.yml` -- Just does a normal build and uploads the resulting wheel as a build asset.
- `validation.yml` -- Runs tests and also does a hygiene check. I'd suggest running `ruff` or `black` during hygiene eventually, but currently it just verifies that the `poetry.lock` file is up-to-date.