### PR TITLE
Upgrade GitHub Actions to actions/checkout@v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     name: Build
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -17,7 +17,7 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Test
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
Noticed these warnings after the initial runs of `validation.yml`. Upgrading to the latest version (v4) should resolve them.

![image](https://github.com/user-attachments/assets/382bcbec-57d5-4d19-8285-dd93147049a0)
