### PR TITLE
Improve logic for calculating result level

### DIFF
--- a/sarif/sarif_file.py
+++ b/sarif/sarif_file.py
@@ -13,6 +13,7 @@ from sarif import sarif_file_utils
 from sarif.sarif_file_utils import (
     SARIF_SEVERITIES_WITHOUT_NONE,
     SARIF_SEVERITIES_WITH_NONE,
+    read_result_severity,
 )
 from sarif.filter.general_filter import GeneralFilter
 from sarif.filter.filter_stats import FilterStats
@@ -250,12 +251,7 @@ class SarifRun:
                         file_path = file_path[prefixlen:]
                     break
 
-        # Get the error severity, if included, and code
-        severity = result.get(
-            "level", "warning"
-        )  # If an error has no specified level then by default it is a warning
-        # TODO: improve this logic to match the rules in
-        # https://docs.oasis-open.org/sarif/sarif/v2.1.0/sarif-v2.1.0.html#_Toc141790898
+        severity = read_result_severity(result, self.run_data)
 
         if "message" in result:
             # per RFC3629 At least one of the text (§3.11.8) or id (§3.11.10) properties SHALL be present https://docs.oasis-open.org/sarif/sarif/v2.1.0/os/sarif-v2.1.0-os.html#RFC3629

--- a/sarif/sarif_file_utils.py
+++ b/sarif/sarif_file_utils.py
@@ -6,7 +6,7 @@ https://docs.oasis-open.org/sarif/sarif/v2.1.0/cs01/sarif-v2.1.0-cs01.html#_Toc1
 """
 
 import textwrap
-from typing import Literal, Union
+from typing import Literal, Tuple, Union
 
 # SARIF severity levels as per
 # https://docs.oasis-open.org/sarif/sarif/v2.1.0/sarif-v2.1.0.html#_Toc141790898
@@ -65,7 +65,7 @@ def combine_record_code_and_description(record: dict) -> str:
     return combine_code_and_description(record["Code"], record["Description"])
 
 
-def read_result_location(result) -> tuple[str, str]:
+def read_result_location(result) -> Tuple[str, str]:
     """
     Extract the file path and line number strings from the Result.
 
@@ -100,7 +100,7 @@ def read_result_location(result) -> tuple[str, str]:
     return (file_path, line_number)
 
 
-def read_result_rule(result, run) -> tuple[Union[dict, None], int]:
+def read_result_rule(result, run) -> Tuple[Union[dict, None], int]:
     """
     Return's the corresponding rule object for the specified result, plus its index
     in the rules array. Follows the rules at

--- a/sarif/sarif_file_utils.py
+++ b/sarif/sarif_file_utils.py
@@ -119,7 +119,7 @@ def read_result_rule(result, run) -> Tuple[Union[dict, None], int]:
 
     rules = run.get("tool", {}).get("driver", {}).get("rules", [])
 
-    if ruleIndex is not None:
+    if ruleIndex is not None and ruleIndex >= 0 and ruleIndex < len(rules):
         return (rules[ruleIndex], ruleIndex)
 
     if ruleId:

--- a/sarif/sarif_file_utils.py
+++ b/sarif/sarif_file_utils.py
@@ -138,12 +138,13 @@ def read_result_invocation(result, run):
     invocationIndex = result.get("provenance", {}).get("invocationIndex")
     if invocationIndex is None:
         return None
-    
-    if invocationIndex < 0:
-        return None
 
     invocations = run.get("invocations")
-    return invocations[invocationIndex]
+
+    if invocations and invocationIndex >= 0 and invocationIndex < len(invocations):
+        return invocations[invocationIndex]
+
+    return None
 
 
 def read_result_severity(result, run) -> Literal["none", "note", "warning", "error"]:

--- a/sarif/sarif_file_utils.py
+++ b/sarif/sarif_file_utils.py
@@ -102,7 +102,8 @@ def read_result_location(result) -> tuple[str, str]:
 
 def read_result_rule(result, run) -> tuple[Union[dict, None], int]:
     """
-    Extract the rule metadata for the result's rule id/index, following the rules at
+    Return's the corresponding rule object for the specified result, plus its index
+    in the rules array. Follows the rules at
     https://docs.oasis-open.org/sarif/sarif/v2.1.0/sarif-v2.1.0.html#_Toc141790895
     """
     ruleIndex = result.get("ruleIndex", None)

--- a/tests/test_sarif_file_utils.py
+++ b/tests/test_sarif_file_utils.py
@@ -35,3 +35,115 @@ def test_combine_code_and_description_long_code():
         long_code, "wow that's a long code"
     )
     assert cd == long_code
+
+
+def test_read_result_rule():
+    run = {"tool":
+           {"driver":
+            {"rules": [
+                {"id": "id0", "defaultConfiguration": {"level": "none"}},
+                {"id": "id1", "defaultConfiguration": {"level": "error"}}
+             ]}}}
+    expectedIndex = 1
+    expectedResult = run["tool"]["driver"]["rules"][expectedIndex]
+
+    result = {}
+    (rule, ruleIndex) = sarif_file_utils.read_result_rule(result, run)
+    assert rule is None
+    assert ruleIndex == -1
+
+    result = {"ruleIndex": "1"}
+    (rule, ruleIndex) = sarif_file_utils.read_result_rule(result, run)
+    assert rule == expectedResult
+    assert ruleIndex == expectedIndex
+
+    result = {"rule": { "index": "1"}}
+    (rule, ruleIndex) = sarif_file_utils.read_result_rule(result, run)
+    assert rule == expectedResult
+    assert ruleIndex == expectedIndex
+
+    result = {"ruleId": "id1"}
+    (rule, ruleIndex) = sarif_file_utils.read_result_rule(result, run)
+    assert rule == expectedResult
+    assert ruleIndex == expectedIndex
+
+    result = {"rule": { "id": "id1"}}
+    (rule, ruleIndex) = sarif_file_utils.read_result_rule(result, run)
+    assert rule == expectedResult
+    assert ruleIndex == expectedIndex
+
+
+def test_read_result_severity():
+    result = {"level": "error"}
+    severity = sarif_file_utils.read_result_severity(result)
+    assert severity == "error"
+
+    # If kind has any value other than "fail", then if level is absent, it SHALL default to "none"...
+    result = {"kind": "other"}
+    severity = sarif_file_utils.read_result_severity(result)
+    assert severity == "none"
+
+    run = {"invocations": [
+             {"ruleConfigurationOverrides": [ {"descriptor": {"id": "id1"}, "configuration": {"level": "note"}} ]},
+             {"ruleConfigurationOverrides": [ {"descriptor": {"index": "1"}, "configuration": {"level": "note"}} ]},
+             { }
+           ],
+           "tool":
+             {"driver":
+               {"rules": [
+                 {"id": "id0", "defaultConfiguration": {"level": "none"}},
+                 {"id": "id1", "defaultConfiguration": {"level": "error"}}
+               ]}
+             }
+           }
+
+    # If kind has the value "fail" and level is absent, then level SHALL be determined by the following procedure:
+    # IF rule is present THEN
+    #   LET theDescriptor be the reportingDescriptor object that it specifies.
+    #   # Is there a configuration override for the level property?
+    #   IF result.provenance.invocationIndex is >= 0 THEN
+    #     LET theInvocation be the invocation object that it specifies.
+    #     IF theInvocation.ruleConfigurationOverrides is present
+    #         AND it contains a configurationOverride object whose
+    #         descriptor property specifies theDescriptor THEN
+    #       LET theOverride be that configurationOverride object.
+    #       IF theOverride.configuration.level is present THEN
+    #         Set level to theConfiguration.level.
+    result = {"ruleIndex": "1", "provenance": {"invocationIndex": "0"}}
+    severity = sarif_file_utils.read_result_severity(result, run)
+    assert severity == "note"
+
+    result = {"ruleIndex": "1", "provenance": {"invocationIndex": "1"}}
+    severity = sarif_file_utils.read_result_severity(result, run)
+    assert severity == "note"
+
+    #   ELSE
+    #     # There is no configuration override for level. Is there a default configuration for it?
+    #     IF theDescriptor.defaultConfiguration.level is present THEN
+    #       SET level to theDescriptor.defaultConfiguration.level.
+
+    result = {"ruleIndex": "1"}
+    severity = sarif_file_utils.read_result_severity(result, run)
+    assert severity == "error"
+
+    result = {"rule": { "index": "1"}}
+    severity = sarif_file_utils.read_result_severity(result, run)
+    assert severity == "error"
+
+    result = {"ruleId": "id1"}
+    severity = sarif_file_utils.read_result_severity(result, run)
+    assert severity == "error"
+
+    result = {"rule": { "id": "id1"}}
+    severity = sarif_file_utils.read_result_severity(result, run)
+    assert severity == "error"
+
+    result = {"ruleIndex": "1", "provenance": {"invocationIndex": "2"}}
+    severity = sarif_file_utils.read_result_severity(result, run)
+    assert severity == "error"
+
+    # IF level has not yet been set THEN
+    #   SET level to "warning".
+    result = {}
+    severity = sarif_file_utils.read_result_severity(result)
+    assert severity == "warning"

--- a/tests/test_sarif_file_utils.py
+++ b/tests/test_sarif_file_utils.py
@@ -44,48 +44,53 @@ def test_read_result_rule():
                 {"id": "id0", "defaultConfiguration": {"level": "none"}},
                 {"id": "id1", "defaultConfiguration": {"level": "error"}}
              ]}}}
-    expectedIndex = 1
-    expectedResult = run["tool"]["driver"]["rules"][expectedIndex]
+    rule_id0 = run["tool"]["driver"]["rules"][0]
+    rule_id1 = run["tool"]["driver"]["rules"][1]
 
     result = {}
     (rule, ruleIndex) = sarif_file_utils.read_result_rule(result, run)
     assert rule is None
     assert ruleIndex == -1
 
-    result = {"ruleIndex": "1"}
+    result = {"ruleIndex": 1}
     (rule, ruleIndex) = sarif_file_utils.read_result_rule(result, run)
-    assert rule == expectedResult
-    assert ruleIndex == expectedIndex
+    assert rule == rule_id1
+    assert ruleIndex == 1
 
-    result = {"rule": { "index": "1"}}
+    result = {"rule": { "index": 1}}
     (rule, ruleIndex) = sarif_file_utils.read_result_rule(result, run)
-    assert rule == expectedResult
-    assert ruleIndex == expectedIndex
+    assert rule == rule_id1
+    assert ruleIndex == 1
 
     result = {"ruleId": "id1"}
     (rule, ruleIndex) = sarif_file_utils.read_result_rule(result, run)
-    assert rule == expectedResult
-    assert ruleIndex == expectedIndex
+    assert rule == rule_id1
+    assert ruleIndex == 1
 
     result = {"rule": { "id": "id1"}}
     (rule, ruleIndex) = sarif_file_utils.read_result_rule(result, run)
-    assert rule == expectedResult
-    assert ruleIndex == expectedIndex
+    assert rule == rule_id1
+    assert ruleIndex == 1
+
+    result = {"ruleIndex": 0}
+    (rule, ruleIndex) = sarif_file_utils.read_result_rule(result, run)
+    assert rule == rule_id0
+    assert ruleIndex == 0
 
 
 def test_read_result_severity():
     result = {"level": "error"}
-    severity = sarif_file_utils.read_result_severity(result)
+    severity = sarif_file_utils.read_result_severity(result, {})
     assert severity == "error"
 
     # If kind has any value other than "fail", then if level is absent, it SHALL default to "none"...
     result = {"kind": "other"}
-    severity = sarif_file_utils.read_result_severity(result)
+    severity = sarif_file_utils.read_result_severity(result, {})
     assert severity == "none"
 
     run = {"invocations": [
              {"ruleConfigurationOverrides": [ {"descriptor": {"id": "id1"}, "configuration": {"level": "note"}} ]},
-             {"ruleConfigurationOverrides": [ {"descriptor": {"index": "1"}, "configuration": {"level": "note"}} ]},
+             {"ruleConfigurationOverrides": [ {"descriptor": {"index": 1}, "configuration": {"level": "note"}} ]},
              { }
            ],
            "tool":
@@ -109,11 +114,11 @@ def test_read_result_severity():
     #       LET theOverride be that configurationOverride object.
     #       IF theOverride.configuration.level is present THEN
     #         Set level to theConfiguration.level.
-    result = {"ruleIndex": "1", "provenance": {"invocationIndex": "0"}}
+    result = {"ruleIndex": 1, "provenance": {"invocationIndex": 0}}
     severity = sarif_file_utils.read_result_severity(result, run)
     assert severity == "note"
 
-    result = {"ruleIndex": "1", "provenance": {"invocationIndex": "1"}}
+    result = {"ruleIndex": 1, "provenance": {"invocationIndex": 1}}
     severity = sarif_file_utils.read_result_severity(result, run)
     assert severity == "note"
 
@@ -122,11 +127,11 @@ def test_read_result_severity():
     #     IF theDescriptor.defaultConfiguration.level is present THEN
     #       SET level to theDescriptor.defaultConfiguration.level.
 
-    result = {"ruleIndex": "1"}
+    result = {"ruleIndex": 1}
     severity = sarif_file_utils.read_result_severity(result, run)
     assert severity == "error"
 
-    result = {"rule": { "index": "1"}}
+    result = {"rule": { "index": 1}}
     severity = sarif_file_utils.read_result_severity(result, run)
     assert severity == "error"
 
@@ -138,12 +143,12 @@ def test_read_result_severity():
     severity = sarif_file_utils.read_result_severity(result, run)
     assert severity == "error"
 
-    result = {"ruleIndex": "1", "provenance": {"invocationIndex": "2"}}
+    result = {"ruleIndex": 1, "provenance": {"invocationIndex": 2}}
     severity = sarif_file_utils.read_result_severity(result, run)
     assert severity == "error"
 
     # IF level has not yet been set THEN
     #   SET level to "warning".
     result = {}
-    severity = sarif_file_utils.read_result_severity(result)
+    severity = sarif_file_utils.read_result_severity(result, {})
     assert severity == "warning"

--- a/tests/test_sarif_file_utils.py
+++ b/tests/test_sarif_file_utils.py
@@ -83,6 +83,37 @@ def test_read_result_rule():
     assert ruleIndex == -1
 
 
+def test_read_result_invocation():
+    run = {"invocations": [
+             {"foo": 1},
+             {"bar": "baz"}
+           ]}
+
+    result = {}
+    invocation = sarif_file_utils.read_result_invocation(result, run)
+    assert invocation is None
+
+    result = {"provenance": {}}
+    invocation = sarif_file_utils.read_result_invocation(result, run)
+    assert invocation is None
+
+    result = {"provenance": {"invocationIndex": 0}}
+    invocation = sarif_file_utils.read_result_invocation(result, {})
+    assert invocation is None
+
+    result = {"provenance": {"invocationIndex": -1}}
+    invocation = sarif_file_utils.read_result_invocation(result, run)
+    assert invocation is None
+
+    result = {"provenance": {"invocationIndex": 2}}
+    invocation = sarif_file_utils.read_result_invocation(result, run)
+    assert invocation is None
+
+    result = {"provenance": {"invocationIndex": 1}}
+    invocation = sarif_file_utils.read_result_invocation(result, run)
+    assert invocation == run["invocations"][1]
+
+
 def test_read_result_severity():
     result = {"level": "error"}
     severity = sarif_file_utils.read_result_severity(result, {})

--- a/tests/test_sarif_file_utils.py
+++ b/tests/test_sarif_file_utils.py
@@ -77,6 +77,11 @@ def test_read_result_rule():
     assert rule == rule_id0
     assert ruleIndex == 0
 
+    result = {"ruleIndex": 0}
+    (rule, ruleIndex) = sarif_file_utils.read_result_rule(result, {})
+    assert rule is None
+    assert ruleIndex == -1
+
 
 def test_read_result_severity():
     result = {"level": "error"}
@@ -150,5 +155,9 @@ def test_read_result_severity():
     # IF level has not yet been set THEN
     #   SET level to "warning".
     result = {}
+    severity = sarif_file_utils.read_result_severity(result, {})
+    assert severity == "warning"
+
+    result = {"ruleIndex": -1}
     severity = sarif_file_utils.read_result_severity(result, {})
     assert severity == "warning"


### PR DESCRIPTION
Fix https://github.com/microsoft/sarif-tools/issues/43

Previously a result's "level" was simply `result.level` or `"warning"` if the result did not specify a level.

This PR updates our level calculation logic to match the rules described in [the SARIF docs](https://docs.oasis-open.org/sarif/sarif/v2.1.0/sarif-v2.1.0.html#_Toc141790898). The precedence order is:
1. `result.level` if present
2. `"none"` if the `result.kind` is not `"fail"`
3. The invocation's override for `level` if present
4. The `level` from the rule's `defaultConfiguration` if present
5. Fall back to `"warning"`