### PR TITLE
Fix crash when using `--check` switch

### DIFF
--- a/sarif/cmdline/main.py
+++ b/sarif/cmdline/main.py
@@ -226,9 +226,8 @@ def _create_arg_parser():
 def _check(input_files: sarif_file.SarifFileSet, check_level):
     ret = 0
     if check_level:
-        counts = input_files.get_result_count_by_severity()
         for severity in sarif_file.SARIF_SEVERITIES_WITH_NONE:
-            ret += counts.get(severity, 0)
+            ret += input_files.get_report().get_issue_count_for_severity(severity)
             if severity == check_level:
                 break
     if ret > 0:

--- a/sarif/sarif_file.py
+++ b/sarif/sarif_file.py
@@ -477,21 +477,6 @@ class SarifFile:
         """
         return sum(run.get_result_count() for run in self.runs)
 
-    def get_result_count_by_severity(self, severities=None) -> Dict[str, int]:
-        """
-        Return a dict from SARIF severity to number of records.
-        """
-        severities = severities or self.get_severities()
-        result_count_by_severity_per_run = [
-            run.get_result_count_by_severity(severities) for run in self.runs
-        ]
-        return {
-            severity: sum(
-                rc.get(severity, 0) for rc in result_count_by_severity_per_run
-            )
-            for severity in severities
-        }
-
     def get_filter_stats(self) -> Optional[FilterStats]:
         """
         Get the number of records that were included or excluded by the filter.

--- a/tests/test_check_switch.py
+++ b/tests/test_check_switch.py
@@ -2,21 +2,12 @@ from sarif.cmdline.main import _check
 from sarif import sarif_file
 
 SARIF = {
-  "runs": [
-    {
-      "tool": {
-        "driver": {
-          "name": "Tool"
-        }
-      },
-      "results": [
+    "runs": [
         {
-          "level": "warning",
-          "ruleId": "rule"
+            "tool": {"driver": {"name": "Tool"}},
+            "results": [{"level": "warning", "ruleId": "rule"}],
         }
-      ]
-    }
-  ]
+    ]
 }
 
 

--- a/tests/test_check_switch.py
+++ b/tests/test_check_switch.py
@@ -1,5 +1,3 @@
-import datetime
-
 from sarif.cmdline.main import _check
 from sarif import sarif_file
 
@@ -30,4 +28,7 @@ def test_check():
     assert result == 0
 
     result = _check(fileSet, "warning")
+    assert result == 1
+
+    result = _check(fileSet, "note")
     assert result == 1

--- a/tests/test_check_switch.py
+++ b/tests/test_check_switch.py
@@ -1,3 +1,4 @@
+import datetime
 from sarif.cmdline.main import _check
 from sarif import sarif_file
 
@@ -13,7 +14,9 @@ SARIF = {
 
 def test_check():
     fileSet = sarif_file.SarifFileSet()
-    fileSet.add_file(sarif_file.SarifFile("SARIF", SARIF))
+    fileSet.add_file(
+        sarif_file.SarifFile("SARIF", SARIF, mtime=datetime.datetime.now())
+    )
 
     result = _check(fileSet, "error")
     assert result == 0

--- a/tests/test_check_switch.py
+++ b/tests/test_check_switch.py
@@ -1,0 +1,33 @@
+import datetime
+
+from sarif.cmdline.main import _check
+from sarif import sarif_file
+
+SARIF = {
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "Tool"
+        }
+      },
+      "results": [
+        {
+          "level": "warning",
+          "ruleId": "rule"
+        }
+      ]
+    }
+  ]
+}
+
+
+def test_check():
+    fileSet = sarif_file.SarifFileSet()
+    fileSet.add_file(sarif_file.SarifFile("SARIF", SARIF))
+
+    result = _check(fileSet, "error")
+    assert result == 0
+
+    result = _check(fileSet, "warning")
+    assert result == 1


### PR DESCRIPTION
Fix #73 

Fixed regression that happened with the introduction of `IssuesReport`. The code that handles `--check` was still trying to call the old `get_result_count_by_severity` API.

- Fixed by using `IssuesReport.get_issue_count_for_severity()` instead. 
- Removed dead `SarifFile.get_result_count_by_severity` code
- Added unit test.