### PR TITLE
Fix line terminators in generated CSV files

### DIFF
--- a/sarif/operations/csv_op.py
+++ b/sarif/operations/csv_op.py
@@ -49,7 +49,6 @@ def _write_to_csv(file_or_files, output_file):
     """
     list_of_errors = file_or_files.get_records()
     severities = file_or_files.get_severities()
-    # newline="" to avoid \r\r\n - see https://stackoverflow.com/a/3191811/316578
     with open(output_file, "w", encoding="utf-8") as file_out:
         writer = csv.DictWriter(
             file_out,

--- a/sarif/operations/csv_op.py
+++ b/sarif/operations/csv_op.py
@@ -50,9 +50,11 @@ def _write_to_csv(file_or_files, output_file):
     list_of_errors = file_or_files.get_records()
     severities = file_or_files.get_severities()
     # newline="" to avoid \r\r\n - see https://stackoverflow.com/a/3191811/316578
-    with open(output_file, "w", encoding="utf-8", newline="") as file_out:
+    with open(output_file, "w", encoding="utf-8") as file_out:
         writer = csv.DictWriter(
-            file_out, sarif_file.get_record_headings(file_or_files.has_blame_info())
+            file_out,
+            sarif_file.get_record_headings(file_or_files.has_blame_info()),
+            lineterminator="\n",
         )
         writer.writeheader()
         for severity in severities:

--- a/sarif/operations/trend_op.py
+++ b/sarif/operations/trend_op.py
@@ -64,7 +64,6 @@ def generate_trend_csv(input_files: SarifFileSet, output_file: str, dateformat: 
 
 
 def _write_csv(output_file: str, error_storage: List[Dict]) -> None:
-    # newline="" to avoid \r\r\n - see https://stackoverflow.com/a/3191811/316578
     with open(output_file, "w", encoding="utf-8") as file_out:
         writer = csv.DictWriter(
             file_out, TIMESTAMP_COLUMNS, extrasaction="ignore", lineterminator="\n"

--- a/sarif/operations/trend_op.py
+++ b/sarif/operations/trend_op.py
@@ -65,8 +65,10 @@ def generate_trend_csv(input_files: SarifFileSet, output_file: str, dateformat: 
 
 def _write_csv(output_file: str, error_storage: List[Dict]) -> None:
     # newline="" to avoid \r\r\n - see https://stackoverflow.com/a/3191811/316578
-    with open(output_file, "w", newline="", encoding="utf-8") as file_out:
-        writer = csv.DictWriter(file_out, TIMESTAMP_COLUMNS, extrasaction="ignore")
+    with open(output_file, "w", encoding="utf-8") as file_out:
+        writer = csv.DictWriter(
+            file_out, TIMESTAMP_COLUMNS, extrasaction="ignore", lineterminator="\n"
+        )
         writer.writeheader()
         for key in error_storage:
             writer.writerow(key)


### PR DESCRIPTION
Fix #82 

For some baffling reason, the `csv` module [defaults to `\r\n` line endings](https://docs.python.org/3.11/library/csv.html#csv.Dialect.lineterminator). When paired with stdlib's default behavior of [translating `\n` to the system default line ending](https://docs.python.org/3.11/library/functions.html#open) this resulted in `\r\r\n` on Windows machines. 

Our first attempt to fix this, back during the Hackathon, was to set `newline=""` on the `open` call. That does result in correct line endings on Windows. But since `csv` defaults to `\r\n` we still end up getting incorrect line endings on Linux.

Fixed by reverting to the default behavior of `open` and telling `csv.DictWriter` to use `\n` as the line terminator.

This is covered by the unit tests I'm about to add in https://github.com/microsoft/sarif-tools/pull/81, but I didn't want this bug fix to be hidden amongst all the test changes.